### PR TITLE
use StripLeadingDirectorySeparators by GetReadmeAsync

### DIFF
--- a/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs
+++ b/src/BaGet.Core/Extensions/PackageArchiveReaderExtensions.cs
@@ -29,6 +29,8 @@ namespace BaGet.Core
                 throw new InvalidOperationException("Package does not have a readme!");
             }
 
+            readmePath = PathUtility.StripLeadingDirectorySeparators(readmePath);
+
             return await package.GetStreamAsync(readmePath, cancellationToken);
         }
 


### PR DESCRIPTION
Allow README to be in a folder other than the root
