### PR TITLE
Using data folder in Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -269,8 +269,8 @@ __pycache__/
 # tools/
 
 # Ignore database files
-**/baget.db
-**/baget.db-shm
-**/baget.db-wal
+**/bagetter.db
+**/bagetter.db-shm
+**/bagetter.db-wal
 
 .vscode/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ Please read the [code of conduct] before contributing.
 If you want to run from BaGetter's source code:
 
 1. Install the [.NET SDK] and [Node.js]
-2. Run `git clone https://github.com/loic-sharma/BaGetter.git`
-3. Navigate to `./BaGet/src/BaGet`
+2. Run `git clone https://github.com/bagetter/BaGetter.git`
+3. Navigate to `./BaGetter/src/BaGetter`
 4. Start the service with `dotnet run`
 5. Open the URL `http://localhost:5000/v3/index.json` in your browser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,14 @@ FROM base AS final
 LABEL org.opencontainers.image.source="https://github.com/bagetter/BaGetter"
 WORKDIR /app
 COPY --from=publish /app .
+
+# Use the /data folder for packages, symbols and the sqlite database
+ENV Storage__Path "/data"
+ENV Search__Type "Database"
+ENV Database__Type "Sqlite"
+ENV Database__ConnectionString "Data Source=/data/db/bagetter.db"
+RUN mkdir -p "/data/packages"
+RUN mkdir -p "/data/symbols"
+RUN mkdir -p  "/data/db"
+
 ENTRYPOINT ["dotnet", "BaGetter.dll"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018 Loic Sharma
+Copyright 2023 BaGetter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/advanced/debugging.md
+++ b/docs/advanced/debugging.md
@@ -1,4 +1,4 @@
-# Debugging BaGet
+# Debugging BaGetter
 
 !!! warning
     This page is a work in progress!

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,7 +66,7 @@ downloaded if you know the package's id and version. You can override this behav
 
 ## Enable package overwrites
 
-Normally, BaGetter will reject a package upload if the id and version are already taken. You can configure BaGet
+Normally, BaGetter will reject a package upload if the id and version are already taken. You can configure BaGetter
 to overwrite the already existing package by setting `AllowPackageOverwrites`:
 
 ```json
@@ -88,7 +88,7 @@ A private feed requires users to authenticate before accessing packages.
 
 ## Database configuration
 
-BaGet supports multiple database engines for storing package information:
+BaGetter supports multiple database engines for storing package information:
 
 
 - MySQL: `MySql`
@@ -118,7 +118,7 @@ The database settings are located under the `Database` key in the `appsettings.j
 
     "Database": {
         "Type": "Sqlite",
-        "ConnectionString": "Data Source=baget.db"
+        "ConnectionString": "Data Source=bagetter.db"
     },
 
     ...

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -1,6 +1,6 @@
 # Run BaGetter on Docker
 
-## Configure BaGet
+## Configure BaGetter
 
 Create a file named `bagetter.env` to store BaGetter's configurations:
 
@@ -10,9 +10,9 @@ Create a file named `bagetter.env` to store BaGetter's configurations:
 ApiKey=NUGET-SERVER-API-KEY
 
 Storage__Type=FileSystem
-Storage__Path=/var/baget/packages
+Storage__Path=/data
 Database__Type=Sqlite
-Database__ConnectionString=Data Source=/var/baget/baget.db
+Database__ConnectionString=Data Source=/data/db/bagetter.db
 Search__Type=Database
 ```
 
@@ -23,10 +23,10 @@ For a full list of configurations, please refer to [BaGetter's configuration](..
     variables. To learn how these configurations work, please refer to
     [ASP.NET Core's configuration documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-2.1&tabs=basicconfiguration#configuration-by-environment).
 
-## Run BaGet
+## Run BaGetter
 
 1. Create a folder named `bagetter-data` in the same directory as the `bagetter.env` file. This will be used by BaGetter to persist its state.
-2. Pull BaGetter's latest [docker image](https://hub.docker.com/r/loicsharma/baget):
+2. Pull BaGetter's latest [docker image](hhttps://hub.docker.com/r/bagetter/bagetter):
 
 ```
 docker pull bagetter/bagetter
@@ -35,7 +35,7 @@ docker pull bagetter/bagetter
 You can now run BaGetter:
 
 ```
-docker run --rm --name nuget-server -p 5555:80 --env-file bagetter.env -v "$(pwd)/baget-data:/var/baget" loicsharma/baget:latest
+docker run --rm --name nuget-server -p 5000:8080 --env-file bagetter.env -v "$(pwd)/bagetter-data:/data" bagetter/bagetter:latest
 ```
 
 ## Publish packages
@@ -53,7 +53,7 @@ dotnet nuget push -s http://localhost:5555/v3/index.json -k NUGET-SERVER-API-KEY
 ```
 
 !!! warning
-    The default API Key to publish packages is `NUGET-SERVER-API-KEY`. You should change this to a secret value to secure your server. See [Configure BaGet](#configure-baget).
+    The default API Key to publish packages is `NUGET-SERVER-API-KEY`. You should change this to a secret value to secure your server. See [Configure BaGetter](#configure-bagetter).
 
 ## Browse packages
 

--- a/readme.md
+++ b/readme.md
@@ -1,15 +1,21 @@
-# BaGetter :baguette_bread:
+# BaGetter 🥖🛒
 
-![Build status]
 
-A lightweight [NuGet] and [symbol] server.
+BaGetter is a lightweight [NuGet] and [symbol] server, written in C#.
+It's forked from [BaGet] for progressive and community driven development.
 
 <p align="center">
   <img width="100%" src="https://user-images.githubusercontent.com/737941/50140219-d8409700-0258-11e9-94c9-dad24d2b48bb.png">
 </p>
 
-## Getting Started
+![Build status] [![Discord][Discord image]][Discord link]
 
+## 🚀 Getting Started
+With Docker:
+1. `docker run -p 5000:8080 -v ./bagetter-data:/data bagetter/bagetter:latest`
+2. Browse `http://localhost:5000/` in your browser
+
+With .NET:
 1. Install the [.NET SDK]
 2. Download and extract [BaGetter's latest release]
 3. Start the service with `dotnet BaGetter.dll`
@@ -17,28 +23,37 @@ A lightweight [NuGet] and [symbol] server.
 
 For more information, please refer to the [documentation].
 
-## Features
+## 📦 Features
 
 * **Cross-platform**: runs on Windows, macOS, and Linux!
 * **Cloud native**: supports [Docker], [Azure], [AWS], [Google Cloud], [Alibaba Cloud]
-* **Offline support**: [mirror a NuGet server] to speed up builds and enable offline downloads
+* **Offline support**: [Mirror a NuGet server] to speed up builds and enable offline downloads
 
-Stay tuned, more features are planned!
+## 🤝 Contributing
 
-[Build status]: https://img.shields.io/github/actions/workflow/status/loic-sharma/BaGet/.github/workflows/main.yml
+We welcome contributions! Check out the [Contributing Guide](CONTRIBUTING.md) to get started.
+
+## 📄 License
+
+This project is licensed under the [MIT License](LICENSE).
+
+## 📞 Contact
+
+If you have questions, feel free to open an [issue] or join our [Discord Server] for discussions.
+
+[Build status]: https://img.shields.io/github/actions/workflow/status/bagetter/BaGetter/.github/workflows/main.yml?logo=github&logoColor=fff
+[Discord image]: https://img.shields.io/discord/1181167608427450388?logo=discord&logoColor=fff
+[Discord link]: https://discord.gg/XsAmm6f2hZ
+[Discord Server]: https://discord.gg/XsAmm6f2hZ
 
 [NuGet]: https://learn.microsoft.com/nuget/what-is-nuget
 [symbol]: https://docs.microsoft.com/en-us/windows/desktop/debug/symbol-servers-and-symbol-stores
 [.NET SDK]: https://www.microsoft.com/net/download
 [Node.js]: https://nodejs.org/
+[Issue]: https://github.com/bagetter/BaGetter/issues
+[BaGet]: https://github.com/loic-sharma/BaGet
 
-[BaGetter's latest release]: https://github.com/bagetter/BaGet/releases
+[BaGetter's latest release]: https://github.com/bagetter/BaGetter/releases
 
-[Documentation]: https://loic-sharma.github.io/BaGet/
-[Docker]: https://loic-sharma.github.io/BaGet/installation/docker/
-[Azure]: https://loic-sharma.github.io/BaGet/installation/azure/
-[AWS]: https://loic-sharma.github.io/BaGet/installation/aws/
-[Google Cloud]: https://loic-sharma.github.io/BaGet/installation/gcp/
-[Alibaba Cloud]: https://loic-sharma.github.io/BaGet/installation/aliyun/
-
-[Mirror a NuGet server]: https://loic-sharma.github.io/BaGet/configuration/#enable-read-through-caching
+[Documentation]: https://www.bagetter.com/
+[Docker]: https://hub.docker.com/r/bagetter/bagetter

--- a/samples/BaGetterWebApplication/appsettings.json
+++ b/samples/BaGetterWebApplication/appsettings.json
@@ -1,6 +1,6 @@
 {
   "Database": {
-    "ConnectionString": "Data Source=baget.db"
+    "ConnectionString": "Data Source=bagetter.db"
   },
 
   "Logging": {

--- a/src/BaGetter/appsettings.json
+++ b/src/BaGetter/appsettings.json
@@ -5,7 +5,7 @@
 
   "Database": {
     "Type": "Sqlite",
-    "ConnectionString": "Data Source=baget.db"
+    "ConnectionString": "Data Source=bagetter.db"
   },
 
   "Storage": {

--- a/src/readme.md
+++ b/src/readme.md
@@ -1,20 +1,20 @@
 # BaGetter Source Code
 
-These folders contain the core components of BaGet:
+These folders contain the core components of BaGetter:
 
-* `BaGet` - The app's entry point that glues everything together.
+* `BaGetter` - The app's entry point that glues everything together.
 * `BaGetter.Core` - BaGetter's core logic and services.
 * `BaGetter.Web` - The [NuGet server APIs](https://docs.microsoft.com/en-us/nuget/api/overview) and web UI.
 * `BaGetter.Protocol` - Libraries to interact with [NuGet servers' APIs](https://docs.microsoft.com/en-us/nuget/api/overview).
 
-These folders contain database-specific components of BaGet:
+These folders contain database-specific components of BaGetter:
 
 * `BaGetter.Database.MySql` - BaGetter's MySQL database provider.
 * `BaGetter.Database.PostgreSql` - BaGetter's PostgreSql database provider.
 * `BaGetter.Database.Sqlite` - BaGetter's SQLite database provider.
 * `BaGetter.Database.SqlServer` - BaGetter's Microsoft SQL Server database provider.
 
-These folders contain cloud-specific components of BaGet:
+These folders contain cloud-specific components of BaGetter:
 
 * `BaGetter.Aliyun` - BaGetter's Alibaba Cloud(Aliyun) provider.
 * `BaGetter.Aws` - BaGetter's Amazon Web Services provider.


### PR DESCRIPTION
Changed the docker container, so it is using the `/data` folder for persisting the packages files, symbols and sqlite db file and not the `/app` folder. The `/data` folder can be pulled-out with a single `-v data:/data` to the docker host.

Changed doc: The default port on the Docker host is 8080 and not 80.

Updated the readme.md