### PR TITLE
Fix broken SemVer2.0.0 link by removing version from package name anchor link

### DIFF
--- a/src/BaGetter.Web/Pages/Index.cshtml
+++ b/src/BaGetter.Web/Pages/Index.cshtml
@@ -115,7 +115,6 @@ else
                 <div>
                     <a asp-page="Package"
                        asp-route-id="@package.PackageId"
-                       asp-route-version="@package.Version"
                        class="package-title">
                         @package.PackageId
                     </a>


### PR DESCRIPTION
Issue Description:
If a package is using a SemVer 2.0.0 version (eg: 4.3.0+build.251.sha.509556a) it's link in the package list will be broken. This is because the version number is used in the anchor link and the characters in a SemVer 2.0.0 version string can break this link.

The following images demonstrate the issue
![semver before](https://github.com/bagetter/BaGetter/assets/40130646/a72cc34f-d13f-48a7-9392-da5523b73ca4)
![semver-error](https://github.com/bagetter/BaGetter/assets/40130646/5691ba15-db38-4b93-a639-fbbb1cc1c9e1)

Solution:
Remove the version number from the anchor link. This is a simple solution and has minimal to no effect (other than fixing the bug) as a link with the latest package version goes to the same page as a link without a package version