### PR TITLE
Create the folders for the Sqlite blob files if they do not exist.

### DIFF
--- a/src/BaGetter.Database.Sqlite/BaGetter.Database.Sqlite.csproj
+++ b/src/BaGetter.Database.Sqlite/BaGetter.Database.Sqlite.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <PackageTags>NuGet</PackageTags>
     <Description>The libraries to host BaGetter on SQLite.</Description>
   </PropertyGroup>

--- a/src/BaGetter.Database.Sqlite/BaGetter.Database.Sqlite.csproj
+++ b/src/BaGetter.Database.Sqlite/BaGetter.Database.Sqlite.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <PackageTags>NuGet</PackageTags>
     <Description>The libraries to host BaGetter on SQLite.</Description>

--- a/src/BaGetter.Database.Sqlite/SqliteContext.cs
+++ b/src/BaGetter.Database.Sqlite/SqliteContext.cs
@@ -64,35 +64,15 @@ namespace BaGetter.Database.Sqlite
 
         /// <summary>
         /// Creates directories specified in the Database::ConnectionString config for the Sqlite database file.
-        /// Respects the difference of root and relative paths.
         /// </summary>
         /// <param name="connection">Instance of the <see cref="SqliteConnection"/>.</param>
         private static void CreateSqliteDataSourceDirectory(SqliteConnection connection)
         {
-            var configDataSource = connection.DataSource;
-            var pathToCreate = Path.IsPathRooted(configDataSource)
-                // root path
-                ? Path.GetDirectoryName(configDataSource)
-                // relative path
-                : CreateFullDataSourcePath();
+            var pathToCreate = Path.GetDirectoryName(connection.DataSource);
 
-            if (pathToCreate is not null)
-            {
-                Directory.CreateDirectory(pathToCreate);
-            }
+            if (pathToCreate is null) return;
 
-            return;
-
-            string CreateFullDataSourcePath()
-            {
-                var exeDir = Directory.GetCurrentDirectory();
-                var relativePath = Path.GetDirectoryName(configDataSource);
-                var relativeDirectoriesArray = relativePath?.Split(Path.DirectorySeparatorChar) ?? [];
-                var relativeDirectoriesCombined = Path.Combine(relativeDirectoriesArray);
-                var fullPath = Path.Combine(exeDir, relativeDirectoriesCombined);
-
-                return fullPath;
-            }
+            Directory.CreateDirectory(pathToCreate);
         }
     }
 }

--- a/src/BaGetter.Database.Sqlite/SqliteContext.cs
+++ b/src/BaGetter.Database.Sqlite/SqliteContext.cs
@@ -1,3 +1,8 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using BaGetter.Core;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -6,6 +11,8 @@ namespace BaGetter.Database.Sqlite
 {
     public class SqliteContext : AbstractContext<SqliteContext>
     {
+        private static readonly Regex WindowsDriveLetterRegex = new("^[A-Za-z]:", RegexOptions.Compiled);
+
         /// <summary>
         /// The Sqlite error code for when a unique constraint is violated.
         /// </summary>
@@ -44,6 +51,76 @@ namespace BaGetter.Database.Sqlite
             builder.Entity<TargetFramework>()
                 .Property(f => f.Moniker)
                 .HasColumnType("TEXT COLLATE NOCASE");
+        }
+
+        public override async Task RunMigrationsAsync(CancellationToken cancellationToken)
+        {
+            if (Database.GetDbConnection() is SqliteConnection connection)
+            {
+                /* Create the folder of the Sqlite blob if it does not exist. */
+                CreateSqliteDataSourceDirectory(connection);
+            }
+
+            await base.RunMigrationsAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates directories specified in the Database::ConnectionString config for the Sqlite database file.
+        /// Respects the difference between Windows and other OS root or relative paths.
+        /// </summary>
+        /// <param name="connection">Instance of the <see cref="SqliteConnection"/>.</param>
+        private static void CreateSqliteDataSourceDirectory(SqliteConnection connection)
+        {
+            var configIsLinuxRootPath = connection.DataSource.StartsWith('/');
+            var configDataSource = connection.DataSource;
+
+            string? pathToCreate = null;
+
+            if (OperatingSystem.IsWindows())
+            {
+                var windowsDriveLetter = Path.GetPathRoot(Directory.GetCurrentDirectory())!;
+
+                // root path
+                if (configIsLinuxRootPath)
+                {
+                    var directories = Path.GetDirectoryName(configDataSource);
+                    if (directories?.Length > 0) pathToCreate = Path.Combine(windowsDriveLetter, directories);
+                }
+                else if (WindowsDriveLetterRegex.IsMatch(configDataSource))
+                {
+                    pathToCreate = Path.GetDirectoryName(configDataSource);
+                }
+                else
+                {
+                    pathToCreate = CreateFullDataSourcePath();
+                }
+            }
+            else
+            {
+                pathToCreate = configIsLinuxRootPath
+                    // root path
+                    ? Path.GetDirectoryName(configDataSource)
+                    // relative path
+                    : CreateFullDataSourcePath();
+            }
+
+            if (pathToCreate is not null)
+            {
+                Directory.CreateDirectory(pathToCreate);
+            }
+
+            return;
+
+            string CreateFullDataSourcePath()
+            {
+                var exeDir = Directory.GetCurrentDirectory();
+                var relativePath = Path.GetDirectoryName(configDataSource);
+                var relativeDirectoriesArray = relativePath?.Split(Path.DirectorySeparatorChar) ?? [];
+                var relativeDirectoriesCombined = Path.Combine(relativeDirectoriesArray);
+                var fullPath = Path.Combine(exeDir, Path.Combine(relativeDirectoriesCombined));
+
+                return fullPath;
+            }
         }
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
   <!-- Compiler properties -->
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>latest</LangVersion>
 
     <!-- Don't warn if there are missing XMl comment for publicly visible type or member-->
     <NoWarn>$(NoWarn);1591</NoWarn>


### PR DESCRIPTION
As mentioned in bagetter/BaGetter#38 under some special configurations Sqlite failed with a "folder not found" exception.
This PR solves this issue. It checks the config and creates the folder under Windows or *nix like OS during the database migration respecting full qualified path or relative paths.

Addresses https://github.com/bagetter/BaGet/issues/38
