### PR TITLE
Allow the use of secret files for configuration

### DIFF
--- a/src/BaGetter/Program.cs
+++ b/src/BaGetter/Program.cs
@@ -67,6 +67,9 @@ namespace BaGetter
                     {
                         config.SetBasePath(root);
                     }
+
+                    // Optionally load secrets from files in the conventional path
+                    config.AddKeyPerFile("/run/secrets", optional: true);
                 })
                 .ConfigureWebHostDefaults(web =>
                 {


### PR DESCRIPTION
(The below is also being prepared for inclusion in the documentation for `bagetter.github.io`.)
## Secret files

Mostly useful when running containerised (e.g. using Docker, Podman, Kubernetes, etc), the application will look for
files named in the same pattern as environment variables under `/run/secrets`, or under the `secrets` subfolder of the
path set by `BAGET_CONFIG_ROOT` - for example, if `BAGET_CONFIG_ROOT=/etc/baget`:

```
/etc/baget/secrets/Database__ConnectionString
/run/secrets/Database__ConnectionString
```

If `BAGET_CONFIG_ROOT` is unset, only the `/run/secrets` path will be used. Currently, the load order is such that
values in `/run/secrets` will supersede those in `/etc/baget/secrets`.

This allows for sensitive values to be provided individually to the application, typically by bind-mounting files. With
a Docker Compose example:

```yaml
version: '2'

services:
  bagetter:
    image: bagetter/bagetter:latest
    volumes:
      # Single file mounted for API key
      - ./secrets/api-key.txt:/run/secrets/ApiKey:ro
      - ./data:/srv/baget
    environment:
      - Database__ConnectionString=Data Source=/srv/baget/bagetter.db
      - Database__Type=Sqlite
      - Mirror__Enabled=false
      - Storage__Type=FileSystem
      - Storage__Path=/srv/baget/packages
```

Upstream documentation for secrets:
- [Docker Swarm secrets](https://docs.docker.com/engine/swarm/secrets/)
- [Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
- [ASP.NET Core Documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-8.0#key-per-file-configuration-provider)