### PR TITLE
Use Array.Empty<T>

### DIFF
--- a/src/BaGetter.Core/Entities/Converters/StringArrayToJsonConverter.cs
+++ b/src/BaGetter.Core/Entities/Converters/StringArrayToJsonConverter.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Newtonsoft.Json;
 
@@ -10,7 +11,7 @@ namespace BaGetter.Core
         public StringArrayToJsonConverter()
             : base(
                 v => JsonConvert.SerializeObject(v),
-                v => (!string.IsNullOrEmpty(v)) ? JsonConvert.DeserializeObject<string[]>(v) : new string[0])
+                v => (!string.IsNullOrEmpty(v)) ? JsonConvert.DeserializeObject<string[]>(v) : Array.Empty<string>())
         {
         }
     }

--- a/src/BaGetter.Core/Extensions/PackageArchiveReaderExtensions.cs
+++ b/src/BaGetter.Core/Extensions/PackageArchiveReaderExtensions.cs
@@ -111,14 +111,14 @@ namespace BaGetter.Core
 
         private static string[] ParseAuthors(string authors)
         {
-            if (string.IsNullOrEmpty(authors)) return new string[0];
+            if (string.IsNullOrEmpty(authors)) return Array.Empty<string>();
 
             return authors.Split(new[] { ',', ';', '\t', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
         private static string[] ParseTags(string tags)
         {
-            if (string.IsNullOrEmpty(tags)) return new string[0];
+            if (string.IsNullOrEmpty(tags)) return Array.Empty<string>();
 
             return tags.Split(new[] { ',', ';', ' ', '\t', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
         }

--- a/tests/BaGetter.Tests/HostIntegrationTests.cs
+++ b/tests/BaGetter.Tests/HostIntegrationTests.cs
@@ -62,7 +62,7 @@ namespace BaGetter.Tests
         private IServiceProvider BuildServiceProvider(Dictionary<string, string> configs = null)
         {
             var host = Program
-                .CreateHostBuilder(new string[0])
+                .CreateHostBuilder(Array.Empty<string>())
                 .ConfigureAppConfiguration((ctx, config) =>
                 {
                     config.AddInMemoryCollection(configs ?? new Dictionary<string, string>());


### PR DESCRIPTION
This PR replaces some `new string[0]` with `Array.Empty<string>()` for better memory management.