### PR TITLE
Fix docusaurus.config.ts

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -41,7 +41,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/${organizationName}/${projectName}/tree/main/',
+            'https://github.com/bagetter/BaGetter/tree/main/',
         },
         theme: {
           customCss: './src/css/custom.css',
@@ -67,7 +67,7 @@ const config: Config = {
           label: 'Docs',
         },
         {
-          href: 'https://github.com/${organizationName}/${projectName}',
+          href: 'https://github.com/bagetter/BaGetter',
           label: 'GitHub',
           position: 'right',
         },
@@ -103,7 +103,7 @@ const config: Config = {
           items: [
             {
               label: 'GitHub',
-              href: 'https://github.com/${organizationName}/${projectName}',
+              href: 'https://github.com/bagetter/BaGetter',
             },
           ],
         },


### PR DESCRIPTION
Fix links to Github and "Edit this page"

Taking a look at [original Docusaurus configuration](https://github.com/facebook/docusaurus/blob/c1ac06768bd3cb997c11931209a97e8c9574c11d/website/docusaurus.config.ts#L398) it seems that usage of "organizationName" and "projectName" configuration variables is very limited.

For example, they cannot be used in "presets" -> "docs" -> "editUrl".

"editUrl" can be a function (see [link1](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#configuration) [link2](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#EditUrlFunction)) but it still doesn't receive the "Config" object.

So, "variables" were replaced with hard-coded values, unfortunatelly