### PR TITLE
Fix local development

### DIFF
--- a/src/BaGetter.Database.Sqlite/SqliteContext.cs
+++ b/src/BaGetter.Database.Sqlite/SqliteContext.cs
@@ -1,6 +1,4 @@
-using System;
 using System.IO;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using BaGetter.Core;
@@ -69,8 +67,10 @@ namespace BaGetter.Database.Sqlite
         private static void CreateSqliteDataSourceDirectory(SqliteConnection connection)
         {
             var pathToCreate = Path.GetDirectoryName(connection.DataSource);
-
-            if (pathToCreate is null) return;
+            if (string.IsNullOrEmpty(pathToCreate))
+            {
+                return;
+            }
 
             Directory.CreateDirectory(pathToCreate);
         }


### PR DESCRIPTION
This PR fixes the local development. Recently there was a fix to create missing directories for SQLite.
Unfortunally this introduced an error when starting the app from VS with `F5` and no further changes after checkout.

![missing_directory](https://github.com/bagetter/BaGetter/assets/6222752/b5618242-88a8-40d8-871b-b3abbe0dbe96)