### PR TITLE
Remove explicit referenced SourceLink

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,6 @@
     <PackageVersion Include="NuGet.Versioning" Version="6.7.0" />
     <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23503-02" />
     <PackageVersion Include="Moq" Version="4.20.69" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,7 +28,6 @@
 
   <!-- Debugging properties -->
   <PropertyGroup>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <DebugType>portable</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
@@ -39,10 +38,6 @@
   <PropertyGroup Condition="'$(CI)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(DOTNET_RUNNING_IN_CONTAINER)' == ''">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
-  </ItemGroup>
 
   <ItemGroup>
     <None Include="../packageIcon.png" Pack="true" PackagePath="" Visible="false" />

--- a/tests/BaGetter.Core.Tests/BaGetter.Core.Tests.csproj
+++ b/tests/BaGetter.Core.Tests/BaGetter.Core.Tests.csproj
@@ -8,16 +8,4 @@
     <ProjectReference Include="..\..\src\BaGetter.Core\BaGetter.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="xunit" />
-    <PackageReference Update="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/tests/BaGetter.Protocol.Tests/BaGetter.Protocol.Tests.csproj
+++ b/tests/BaGetter.Protocol.Tests/BaGetter.Protocol.Tests.csproj
@@ -23,16 +23,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="xunit" />
-    <PackageReference Update="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/tests/BaGetter.Tests/BaGetter.Tests.csproj
+++ b/tests/BaGetter.Tests/BaGetter.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -39,18 +38,6 @@
     <EmbeddedResource Include="TestData\TestData.1.2.3.snupkg">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="xunit" />
-    <PackageReference Update="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tests/BaGetter.Web.Tests/BaGetter.Web.Tests.csproj
+++ b/tests/BaGetter.Web.Tests/BaGetter.Web.Tests.csproj
@@ -8,16 +8,4 @@
     <ProjectReference Include="..\..\src\BaGetter.Web\BaGetter.Web.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Update="xunit" />
-    <PackageReference Update="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,13 +1,12 @@
 <Project>
 
   <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>
     <DebugType>portable</DebugType>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR removes the explicit reference to `Microsoft.SourceLink.GitHub` because it is included in the SDK.
Also the `pdb` files are removed from the `nupkg` to save some space.
According to the documentation this is only needed for older versions of VisualStudio (which don't support .NET 8).

I also removed some duplicate entries in the test projects.

https://github.com/dotnet/sourcelink#using-source-link-in-net-projects
>...
> If your project uses .NET SDK 8+ and is hosted by the above providers it does not need to reference any Source Link packages or set any build properties.
> Referencing any Source Link package in a .NET SDK 8+ project suppresses Source Link that is included in the SDK.
> ...

https://github.com/dotnet/sourcelink#pdb-distributions
> ...
> If you distribute the library via a package published to [NuGet.org](http://nuget.org/), it is recommended to build a [symbol package](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg)  **(which is done by this project)**
> ...
> **Alternatively**, Portable PDBs can be included in the main NuGet package
> ...