### PR TITLE
Fix Todo comment (derived classes in registration)

### DIFF
--- a/src/BaGetter.Core/Metadata/BaGetRegistrationIndexPageItem.cs
+++ b/src/BaGetter.Core/Metadata/BaGetRegistrationIndexPageItem.cs
@@ -5,29 +5,16 @@ namespace BaGetter.Core
 {
     /// <summary>
     /// BaGetter's extensions to a registration index page.
-    /// Extends <see cref="RegistrationIndexPageItem"/>.
     /// </summary>
-    /// <remarks>
-    /// TODO: After this project is updated to .NET 5, make <see cref="BaGetRegistrationIndexPageItem"/>
-    /// extend <see cref="RegistrationIndexPageItem"/> and remove identical properties.
-    /// Properties that are modified should be marked with the "new" modified.
-    /// See: https://github.com/dotnet/runtime/pull/32107
-    /// </remarks>
-    public class BaGetRegistrationIndexPageItem
+    /// <remarks>Extends <see cref="RegistrationIndexPageItem"/>.</remarks>
+    public class BaGetRegistrationIndexPageItem : RegistrationIndexPageItem
     {
-#region Original properties from RegistrationIndexPageItem.
-        [JsonPropertyName("@id")]
-        public string RegistrationLeafUrl { get; set; }
-
-        [JsonPropertyName("packageContent")]
-        public string PackageContentUrl { get; set; }
-#endregion
-
         /// <summary>
         /// The catalog entry containing the package metadata.
-        /// This was modified to use BaGetter's extended package metadata model.
         /// </summary>
+        /// <remarks>This was modified to use BaGetter's extended package metadata model.</remarks>
         [JsonPropertyName("catalogEntry")]
-        public BaGetterPackageMetadata PackageMetadata { get; set; }
+        [JsonPropertyOrder(int.MaxValue)]
+        public new BaGetterPackageMetadata PackageMetadata { get; set; }
     }
 }

--- a/src/BaGetter.Core/Metadata/BaGetterPackageMetadata.cs
+++ b/src/BaGetter.Core/Metadata/BaGetterPackageMetadata.cs
@@ -5,9 +5,11 @@ using BaGetter.Protocol.Models;
 namespace BaGetter.Core
 {
     /// <summary>
-    /// BaGetter's extensions to the package metadata model. These additions
-    /// are not part of the official protocol.
+    /// BaGetter's extensions to the package metadata model.
     /// </summary>
+    /// <remarks><para>Extends <see cref="PackageMetadata"/>.</para>
+    /// These additions are not part of the official protocol.
+    /// </remarks>
     public class BaGetterPackageMetadata : PackageMetadata
     {
         [JsonPropertyName("downloads")]

--- a/src/BaGetter.Core/Metadata/BaGetterRegistrationIndexPage.cs
+++ b/src/BaGetter.Core/Metadata/BaGetterRegistrationIndexPage.cs
@@ -6,34 +6,17 @@ namespace BaGetter.Core
 {
     /// <summary>
     /// BaGetter's extensions to a registration index page.
-    /// Extends <see cref="RegistrationIndexPage"/>.
     /// </summary>
-    /// <remarks>
-    /// TODO: After this project is updated to .NET 5, make <see cref="BaGetterRegistrationIndexPage"/>
-    /// extend <see cref="RegistrationIndexPage"/> and remove identical properties.
-    /// Properties that are modified should be marked with the "new" modified.
-    /// See: https://github.com/dotnet/runtime/pull/32107
-    /// </remarks>
-    public class BaGetterRegistrationIndexPage
+    /// <remarks>Extends <see cref="RegistrationIndexPage"/>.</remarks>
+    public class BaGetterRegistrationIndexPage : RegistrationIndexPage
     {
-#region Original properties from RegistrationIndexPage.
-        [JsonPropertyName("@id")]
-        public string RegistrationPageUrl { get; set; }
-
-        [JsonPropertyName("count")]
-        public int Count { get; set; }
-
-        [JsonPropertyName("lower")]
-        public string Lower { get; set; }
-
-        [JsonPropertyName("upper")]
-        public string Upper { get; set; }
-#endregion
-
         /// <summary>
-        /// This was modified to use BaGetter's extended registration index page item model.
+        /// <see langword="null"/> if this package's registration is paged. The items can be found
+        /// by following the page's <see cref="RegistrationIndexPage.RegistrationPageUrl"/>.
         /// </summary>
+        /// <remarks>This was modified to use BaGetter's extended registration index page item model.</remarks>
         [JsonPropertyName("items")]
-        public IReadOnlyList<BaGetRegistrationIndexPageItem> ItemsOrNull { get; set; }
+        [JsonPropertyOrder(int.MaxValue)]
+        public new IReadOnlyList<BaGetRegistrationIndexPageItem> ItemsOrNull { get; set; }
     }
 }

--- a/src/BaGetter.Core/Metadata/BaGetterRegistrationIndexResponse.cs
+++ b/src/BaGetter.Core/Metadata/BaGetterRegistrationIndexResponse.cs
@@ -6,40 +6,24 @@ namespace BaGetter.Core
 {
     /// <summary>
     /// BaGetter's extensions to a registration index response.
-    /// Extends <see cref="RegistrationIndexResponse"/>.
     /// </summary>
-    /// <remarks>
-    /// TODO: After this project is updated to .NET 5, make <see cref="BaGetterRegistrationIndexResponse"/>
-    /// extend <see cref="RegistrationIndexResponse"/> and remove identical properties.
-    /// Properties that are modified should be marked with the "new" modified.
-    /// See: https://github.com/dotnet/runtime/pull/32107
-    /// </remarks>
-    public class BaGetterRegistrationIndexResponse
+    /// <remarks>Extends <see cref="RegistrationIndexResponse"/>.</remarks>
+    public class BaGetterRegistrationIndexResponse : RegistrationIndexResponse
     {
-#region Original properties from RegistrationIndexResponse.
-        [JsonPropertyName("@id")]
-        public string RegistrationIndexUrl { get; set; }
-
-        [JsonPropertyName("@type")]
-        public IReadOnlyList<string> Type { get; set; }
-
-        [JsonPropertyName("count")]
-        public int Count { get; set; }
-#endregion
-
         /// <summary>
-        /// The pages that contain all of the versions of the package, ordered
-        /// by the package's version. This was modified to use BaGetter's extended
-        /// registration index page model.
+        /// The pages that contain all of the versions of the package, ordered by the package's version.
         /// </summary>
+        /// <remarks>This was modified to use BaGetter's extended registration index page model.</remarks>
         [JsonPropertyName("items")]
-        public IReadOnlyList<BaGetterRegistrationIndexPage> Pages { get; set; }
+        [JsonPropertyOrder(int.MaxValue)]
+        public new IReadOnlyList<BaGetterRegistrationIndexPage> Pages { get; set; }
 
         /// <summary>
         /// The package's total downloads across all versions.
-        /// This is not part of the official NuGet protocol.
         /// </summary>
+        /// <remarks>This is not part of the official NuGet protocol.</remarks>
         [JsonPropertyName("totalDownloads")]
+        [JsonPropertyOrder(int.MaxValue)]
         public long TotalDownloads { get; set; }
     }
 }

--- a/tests/BaGetter.Core.Tests/Metadata/ModelTests.cs
+++ b/tests/BaGetter.Core.Tests/Metadata/ModelTests.cs
@@ -121,10 +121,10 @@ namespace BaGetter.Core.Tests.Metadata
                 .GetProperties()
                 .ToDictionary(p => p.Name, p => p);
 
-            IReadOnlyDictionary<(Type type, string name), PropertyInfo> derivedProperties = data
+            IReadOnlyDictionary<string, PropertyInfo> derivedProperties = data
                 .DerivedType
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                .ToDictionary(p => (p.DeclaringType, p.Name), p => p);
+                .ToDictionary(p => p.Name, p => p);
 
             // Act/Assert
 

--- a/tests/BaGetter.Tests/BaGetter.Tests.csproj
+++ b/tests/BaGetter.Tests/BaGetter.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>    
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR fixes a TODO comment.
As mentioned all classes (in registration) do derive now from the base classes.
The tests were adjusted accordingly.

The `[JsonPropertyOrder(int.MaxValue)]` is necessary, because otherwise the properties of the base class are serialized last and too many tests had to be adjusted.