### PR TITLE
Fix: NuGet release problem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,85 +6,111 @@ on:
       releaseVersion:
         description: 'Release version'
         required: true
-        default: '1.0.0-preview1'
+        default: '0.0.0'
       packageSource:
         description: 'Package source'
         required: true
         default: 'https://api.nuget.org/v3/index.json'
-
-env:
-  Version: ${{ github.event.inputs.releaseVersion }}
-  PackageVersion: ${{ github.event.inputs.releaseVersion }}
+  push:
+    tags:
+      - 'v*.*.*'
 
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - id: get-version-tag
+        run: |
+          export GITHUB_REF_NAME="${{ github.ref_name }}"
+          export RELEASE_VERSION="${GITHUB_REF_NAME#v}"
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+    outputs:
+      RELEASE_VERSION: ${{ steps.get-version-tag.outputs.RELEASE_VERSION }}
+
   verify:
     name: Run tests
     runs-on: ubuntu-latest
-
+    needs: version
     steps:
-    - uses: actions/checkout@v4.1.1
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4.0.0
-      with:
-        global-json-file: global.json
-    - name: Test
-      run: dotnet test --verbosity normal
+      - uses: actions/checkout@v4.1.1
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4.0.0
+        with:
+          global-json-file: global.json
+      - name: Test
+        run: dotnet test --verbosity normal
 
   release_zip:
-    needs: verify
+    if: ${{ github.ref_type == 'tag' }}
+    needs: [version, verify]
     name: Release BaGetter.zip to GitHub
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     steps:
-    - uses: actions/checkout@v4.1.1
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4.0.0
-      with:
-        global-json-file: global.json
-    - name: Publish
-      run: dotnet publish src/BaGetter --configuration Release --output artifacts
-    - name: Upload
-      uses: actions/upload-artifact@v4.3.0
-      with:
-        name: BaGetter_${{ github.event.inputs.releaseVersion }}
-        path: artifacts
-        if-no-files-found: error
+      - uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4.0.0
+        with:
+          global-json-file: global.json
+      - name: Publish
+        run: |
+          dotnet publish src/BaGetter --configuration Release --output artifacts
+          echo ${{ github.sha }} > artifacts/ReleaseSha.txt
+          7z a -tzip bagetter-${{ needs.version.outputs.RELEASE_VERSION }}.zip ./artifacts/*
+      - name: Generate changelog with git-cliff
+        uses: tj-actions/git-cliff@v1.4.2
+        with:
+          args: --latest --strip all
+          output: "CHANGELOG.md"
+      - name: Create release with ncipollo/release-action
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          bodyFile: "CHANGELOG.md"
+          artifacts: "bagetter-${{ needs.version.outputs.RELEASE_VERSION }}.zip"
+          name: ${{ needs.version.outputs.RELEASE_VERSION }}
+          prerelease: ${{ contains(github.ref_name, '-') }}
 
   release_packages:
-    needs: verify
+    if: ${{ github.ref_type == 'tag' }}
+    needs: [version, verify]
     name: Release packages to nuget.org
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4.1.1
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4.0.0
-      with:
-        global-json-file: global.json
-    - name: Pack
-      run: dotnet pack --configuration Release --output artifacts
-    - name: Push
-      run: dotnet nuget push "*" -s ${{ github.event.inputs.packageSource }} -k ${{secrets.NUGET_API_KEY}}
-      working-directory: artifacts
+      - uses: actions/checkout@v4.1.1
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4.0.0
+        with:
+          global-json-file: global.json
+      - name: Pack
+        run: |
+          export PackageVersion=${{ needs.version.outputs.RELEASE_VERSION }}
+          dotnet pack --configuration Release --output artifacts
+      - name: Push
+        run: dotnet nuget push "*" -s ${{ github.event.inputs.packageSource }} -k ${{secrets.NUGET_API_KEY}}
+        working-directory: artifacts
 
   release_docker_image:
-    needs: verify
+    if: ${{ github.ref_type == 'tag' }}
+    needs: [version, verify]
     name: Release Docker image to Docker Hub
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4.1.1
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3.0.0
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v5.1.0
-      with:
-        context: .
-        push: true
-        tags: |
-          bagetter/bagetter:latest
-          bagetter/bagetter:${{ github.event.inputs.releaseVersion }}
+      - uses: actions/checkout@v4.1.1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set release version
+        run: echo "PackageVersion=${{ needs.version.outputs.RELEASE_VERSION }}" >> $GITHUB_ENV
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5.1.0
+        with:
+          context: .
+          push: true
+          tags: |
+            bagetter/bagetter:latest
+            bagetter/bagetter:${{ needs.version.outputs.RELEASE_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,6 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      releaseVersion:
-        description: 'Release version'
-        required: true
-        default: '0.0.0'
-      packageSource:
-        description: 'Package source'
-        required: true
-        default: 'https://api.nuget.org/v3/index.json'
   push:
     tags:
       - 'v*.*.*'
@@ -87,9 +77,12 @@ jobs:
       - name: Pack
         run: |
           export PackageVersion=${{ needs.version.outputs.RELEASE_VERSION }}
+          export PackageSource=${{ github.event.inputs.packageSource }}
+          PackageSource=${PackageSource:="https://api.nuget.org/v3/index.json"}
+          echo "PackageSource=${PackageSource}" >> $GITHUB_ENV
           dotnet pack --configuration Release --output artifacts
       - name: Push
-        run: dotnet nuget push "*" -s ${{ github.event.inputs.packageSource }} -k ${{secrets.NUGET_API_KEY}}
+        run: dotnet nuget push "*" -s ${PackageSource} -k ${{secrets.NUGET_API_KEY}}
         working-directory: artifacts
 
   release_docker_image:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,7 @@ jobs:
       - name: Pack
         run: |
           export PackageVersion=${{ needs.version.outputs.RELEASE_VERSION }}
-          export PackageSource=${{ github.event.inputs.packageSource }}
-          PackageSource=${PackageSource:="https://api.nuget.org/v3/index.json"}
+          export PackageSource=${PackageSource:="https://api.nuget.org/v3/index.json"}
           echo "PackageSource=${PackageSource}" >> $GITHUB_ENV
           dotnet pack --configuration Release --output artifacts
       - name: Push


### PR DESCRIPTION
This PR fixes a mistake reading the `PackageSource` variable which is required for publishing to api.nuget.org.
