### PR TITLE
Alter format of some xml documentation comments

### DIFF
--- a/src/BaGetter.Protocol/Catalog/CatalogProcessor.cs
+++ b/src/BaGetter.Protocol/Catalog/CatalogProcessor.cs
@@ -6,12 +6,13 @@ using Microsoft.Extensions.Logging;
 
 namespace BaGetter.Protocol.Catalog
 {
-    // This class is based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/CatalogProcessor.cs
-
     /// <summary>
     /// Processes catalog leafs in chronological order.
-    /// </summary>
-    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource"/></remarks>
+    /// </summary>    
+    /// <remarks>
+    /// See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource"/><br/>
+    /// Based off: <see href="https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/CatalogProcessor.cs"/>
+    /// </remarks>
     public class CatalogProcessor
     {
         private readonly ICatalogLeafProcessor _leafProcessor;

--- a/src/BaGetter.Protocol/Catalog/CatalogProcessor.cs
+++ b/src/BaGetter.Protocol/Catalog/CatalogProcessor.cs
@@ -6,11 +6,12 @@ using Microsoft.Extensions.Logging;
 
 namespace BaGetter.Protocol.Catalog
 {
+    // This class is based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/CatalogProcessor.cs
+
     /// <summary>
     /// Processes catalog leafs in chronological order.
-    /// See: https://docs.microsoft.com/en-us/nuget/api/catalog-resource
-    /// Based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/CatalogProcessor.cs
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource"/></remarks>
     public class CatalogProcessor
     {
         private readonly ICatalogLeafProcessor _leafProcessor;

--- a/src/BaGetter.Protocol/Catalog/CatalogProcessorOptions.cs
+++ b/src/BaGetter.Protocol/Catalog/CatalogProcessorOptions.cs
@@ -2,11 +2,10 @@ using System;
 
 namespace BaGetter.Protocol.Catalog
 {
-    // This class is based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/CatalogProcessorSettings.cs
-
     /// <summary>
     /// The options to configure <see cref="CatalogProcessor"/>.
     /// </summary>
+    /// <remarks>Based off: <see href="https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/CatalogProcessorSettings.cs"/></remarks>
     public class CatalogProcessorOptions
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Catalog/CatalogProcessorOptions.cs
+++ b/src/BaGetter.Protocol/Catalog/CatalogProcessorOptions.cs
@@ -2,9 +2,10 @@ using System;
 
 namespace BaGetter.Protocol.Catalog
 {
+    // This class is based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/CatalogProcessorSettings.cs
+
     /// <summary>
     /// The options to configure <see cref="CatalogProcessor"/>.
-    /// Based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/CatalogProcessorSettings.cs
     /// </summary>
     public class CatalogProcessorOptions
     {

--- a/src/BaGetter.Protocol/Catalog/FileCursor.cs
+++ b/src/BaGetter.Protocol/Catalog/FileCursor.cs
@@ -8,12 +8,11 @@ using Microsoft.Extensions.Logging;
 
 namespace BaGetter.Protocol.Catalog
 {
-    // This class is based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/FileCursor.cs
-
     /// <summary>
-    /// A cursor implementation which stores the cursor in local file. The cursor value is written to the file as
-    /// a JSON object.
+    /// A cursor implementation which stores the cursor in local file.<br/>
+    /// The cursor value is written to the file as a JSON object.
     /// </summary>
+    /// <remarks>Based off: <see href="https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/FileCursor.cs"/></remarks>
     public class FileCursor : ICursor
     {
         private readonly string _path;

--- a/src/BaGetter.Protocol/Catalog/FileCursor.cs
+++ b/src/BaGetter.Protocol/Catalog/FileCursor.cs
@@ -8,10 +8,11 @@ using Microsoft.Extensions.Logging;
 
 namespace BaGetter.Protocol.Catalog
 {
+    // This class is based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/FileCursor.cs
+
     /// <summary>
     /// A cursor implementation which stores the cursor in local file. The cursor value is written to the file as
     /// a JSON object.
-    /// Based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/FileCursor.cs
     /// </summary>
     public class FileCursor : ICursor
     {

--- a/src/BaGetter.Protocol/Catalog/ICatalogClient.cs
+++ b/src/BaGetter.Protocol/Catalog/ICatalogClient.cs
@@ -5,7 +5,7 @@ using BaGetter.Protocol.Models;
 namespace BaGetter.Protocol
 {
     /// <summary>
-    /// The Catalog client, used to discover package events.
+    /// The Catalog client, used to discover package events.<br/>
     /// You can use this resource to query for all published packages.
     /// </summary>
     /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource"/></remarks>

--- a/src/BaGetter.Protocol/Catalog/ICatalogClient.cs
+++ b/src/BaGetter.Protocol/Catalog/ICatalogClient.cs
@@ -7,23 +7,22 @@ namespace BaGetter.Protocol
     /// <summary>
     /// The Catalog client, used to discover package events.
     /// You can use this resource to query for all published packages.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/catalog-resource
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource"/></remarks>
     public interface ICatalogClient
     {
         /// <summary>
         /// Get the entry point for the catalog resource.
-        /// See: https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-index
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-index"/></remarks>
         /// <param name="cancellationToken">A token to cancel the task.</param>
         /// <returns>The catalog index.</returns>
         Task<CatalogIndex> GetIndexAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a single catalog page, used to discover catalog leafs.
-        /// See: https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-page
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-page"/></remarks>
         /// <param name="pageUrl">The URL of the page, from the <see cref="CatalogIndex"/>.</param>
         /// <param name="cancellationToken">A token to cancel the task.</param>
         /// <returns>A catalog page.</returns>
@@ -33,8 +32,8 @@ namespace BaGetter.Protocol
 
         /// <summary>
         /// Get a single catalog leaf, representing a package deletion event.
-        /// See: https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf"/></remarks>
         /// <param name="leafUrl">The URL of the leaf, from a <see cref="CatalogPage"/>.</param>
         /// <param name="cancellationToken">A token to cancel the task.</param>
         /// <returns>A catalog leaf.</returns>
@@ -44,8 +43,8 @@ namespace BaGetter.Protocol
 
         /// <summary>
         /// Get a single catalog leaf, representing a package creation or update event.
-        /// See: https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf"/></remarks>
         /// <param name="leafUrl">The URL of the leaf, from a <see cref="CatalogPage"/>.</param>
         /// <param name="cancellationToken">A token to cancel the task.</param>
         /// <returns>A catalog leaf.</returns>

--- a/src/BaGetter.Protocol/Catalog/ICatalogLeafProcessor.cs
+++ b/src/BaGetter.Protocol/Catalog/ICatalogLeafProcessor.cs
@@ -4,36 +4,39 @@ using BaGetter.Protocol.Models;
 
 namespace BaGetter.Protocol.Catalog
 {
-    // This class is based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/master/src/NuGet.Protocol.Catalog/ICatalogLeafProcessor.cs
-
     /// <summary>
-    /// An interface which allows custom processing of catalog leaves. This interface should be implemented when the
-    /// catalog leaf documents need to be downloaded and processed in chronological order.
+    /// An interface which allows custom processing of catalog leaves.<br/>
+    /// This interface should be implemented when the catalog leaf documents need to be downloaded and processed in chronological order.
     /// </summary>
+    /// <remarks>Based off: <see href="https://github.com/NuGet/NuGet.Services.Metadata/blob/master/src/NuGet.Protocol.Catalog/ICatalogLeafProcessor.cs"/></remarks>
     public interface ICatalogLeafProcessor
     {
         /// <summary>
-        /// Process a catalog leaf containing package details. This method should return false or throw an exception
-        /// if the catalog leaf cannot be processed. In this case, the <see cref="CatalogProcessor" /> will stop
-        /// processing items. Note that the same package ID/version combination can be passed to this multiple times,
-        /// for example due to an edit in the package metadata or due to a transient error and retry on the part of the
-        /// <see cref="CatalogProcessor" />.
+        /// Process a catalog leaf containing package details.
         /// </summary>
+        /// <remarks>
+        /// This method should return <see langword="false"/> or throw an exception if the catalog leaf cannot be processed.<br/>
+        /// In this case, the <see cref="CatalogProcessor" /> will stop processing items.<br/>
+        /// Note that the same package ID/version combination can be passed to this multiple times, for example due to an edit in the package metadata
+        /// or due to a transient error and retry on the part of the <see cref="CatalogProcessor" />.
+        /// </remarks>
         /// <param name="leaf">The leaf document.</param>
         /// <param name="cancellationToken">A token to cancel the task.</param>
-        /// <returns>True, if the leaf was successfully processed. False, otherwise.</returns>
+        /// <returns><see langword="True"/>, if the leaf was successfully processed, otherwise <see langword="false"/>.</returns>
         Task<bool> ProcessPackageDetailsAsync(PackageDetailsCatalogLeaf leaf, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Process a catalog leaf containing a package delete. This method should return false or throw an exception
-        /// if the catalog leaf cannot be processed. In this case, the <see cref="CatalogProcessor" /> will stop
-        /// processing items. Note that the same package ID/version combination can be passed to this multiple times,
-        /// for example due to a package being deleted again due to a transient error and retry on the part of the
-        /// <see cref="CatalogProcessor" />.
+        /// Process a catalog leaf containing a package delete.
         /// </summary>
+        /// <remarks>
+        /// This method should return <see langword="false"/> or throw an exception if the catalog leaf cannot be processed.<br/>
+        /// In this case, the <see cref="CatalogProcessor" /> will stop processing items.<br/>
+        /// Note that the same package ID/version combination can be passed to this multiple times, for example due to a package being deleted
+        /// again due to a transient error and retry on the part of the <see cref="CatalogProcessor" />.
+        /// </remarks>
         /// <param name="leaf">The leaf document.</param>
         /// <param name="cancellationToken">A token to cancel the task.</param>
-        /// <returns>True, if the leaf was successfully processed. False, otherwise.</returns>
+        /// <returns><see langword="True"/>, if the leaf was successfully processed, otherwise <see langword="false"/>.</returns>
         Task<bool> ProcessPackageDeleteAsync(PackageDeleteCatalogLeaf leaf, CancellationToken cancellationToken = default);
     }
 }

--- a/src/BaGetter.Protocol/Catalog/ICatalogLeafProcessor.cs
+++ b/src/BaGetter.Protocol/Catalog/ICatalogLeafProcessor.cs
@@ -4,10 +4,11 @@ using BaGetter.Protocol.Models;
 
 namespace BaGetter.Protocol.Catalog
 {
+    // This class is based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/master/src/NuGet.Protocol.Catalog/ICatalogLeafProcessor.cs
+
     /// <summary>
     /// An interface which allows custom processing of catalog leaves. This interface should be implemented when the
     /// catalog leaf documents need to be downloaded and processed in chronological order.
-    /// Based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/master/src/NuGet.Protocol.Catalog/ICatalogLeafProcessor.cs
     /// </summary>
     public interface ICatalogLeafProcessor
     {

--- a/src/BaGetter.Protocol/Catalog/ICursor.cs
+++ b/src/BaGetter.Protocol/Catalog/ICursor.cs
@@ -4,13 +4,14 @@ using System.Threading.Tasks;
 
 namespace BaGetter.Protocol.Catalog
 {
+    // This class is based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/ICursor.cs
+
     /// <summary>
     /// The NuGet Catalog resource is an append-only data structure indexed by time.
     /// The <see cref="ICursor"/> tracks up to what point in the catalog has been successfully
     /// processed. The value is a catalog commit timestamp.
-    /// See: https://docs.microsoft.com/en-us/nuget/api/catalog-resource#cursor
-    /// Based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/ICursor.cs
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#cursor"/></remarks>
     public interface ICursor
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Catalog/ICursor.cs
+++ b/src/BaGetter.Protocol/Catalog/ICursor.cs
@@ -4,14 +4,15 @@ using System.Threading.Tasks;
 
 namespace BaGetter.Protocol.Catalog
 {
-    // This class is based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/ICursor.cs
-
     /// <summary>
-    /// The NuGet Catalog resource is an append-only data structure indexed by time.
+    /// The NuGet Catalog resource is an append-only data structure indexed by time.<br/>
     /// The <see cref="ICursor"/> tracks up to what point in the catalog has been successfully
     /// processed. The value is a catalog commit timestamp.
     /// </summary>
-    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#cursor"/></remarks>
+    /// <remarks>
+    /// See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#cursor"/><br/>
+    /// Based off: <see href="https://github.com/NuGet/NuGet.Services.Metadata/blob/3a468fe534a03dcced897eb5992209fdd3c4b6c9/src/NuGet.Protocol.Catalog/ICursor.cs"/>
+    /// </remarks>
     public interface ICursor
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Catalog/NullCursor.cs
+++ b/src/BaGetter.Protocol/Catalog/NullCursor.cs
@@ -5,9 +5,8 @@ using System.Threading.Tasks;
 namespace BaGetter.Protocol.Catalog
 {
     /// <summary>
-    /// A cursor that does not persist any state. Use this with a <see cref="CatalogProcessor"/>
-    /// to process all leafs each time <see cref="CatalogProcessor.ProcessAsync(CancellationToken)"/>
-    /// is called.
+    /// A cursor that does not persist any state.<br/>
+    /// Use this with a <see cref="CatalogProcessor"/> to process all leafs each time <see cref="CatalogProcessor.ProcessAsync(CancellationToken)"/> is called.
     /// </summary>
     public class NullCursor : ICursor
     {

--- a/src/BaGetter.Protocol/Extensions/CatalogModelExtensions.cs
+++ b/src/BaGetter.Protocol/Extensions/CatalogModelExtensions.cs
@@ -7,9 +7,10 @@ using NuGet.Versioning;
 
 namespace BaGetter.Protocol
 {
+    // This class is based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/ModelExtensions.cs
+
     /// <summary>
     /// These are documented interpretations of values returned by the catalog API.
-    /// Based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/ModelExtensions.cs
     /// </summary>
     public static class CatalogModelExtensions
     {

--- a/src/BaGetter.Protocol/Extensions/CatalogModelExtensions.cs
+++ b/src/BaGetter.Protocol/Extensions/CatalogModelExtensions.cs
@@ -7,16 +7,15 @@ using NuGet.Versioning;
 
 namespace BaGetter.Protocol
 {
-    // This class is based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/ModelExtensions.cs
-
     /// <summary>
     /// These are documented interpretations of values returned by the catalog API.
     /// </summary>
+    /// <remarks>Based off: <see href="https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/ModelExtensions.cs"/></remarks>
     public static class CatalogModelExtensions
     {
         /// <summary>
-        /// Gets the leaves that lie within the provided commit timestamp bounds. The result is sorted by commit
-        /// timestamp, then package ID, then package version (SemVer order).
+        /// Gets the leaves that lie within the provided commit timestamp bounds.<br/>
+        /// The result is sorted by commit timestamp, then package ID, then package version (SemVer order).
         /// </summary>
         /// <param name="catalogPage"></param>
         /// <param name="minCommitTimestamp">The exclusive lower time bound on <see cref="CatalogLeafItem.CommitTimestamp"/>.</param>
@@ -52,8 +51,8 @@ namespace BaGetter.Protocol
         }
 
         /// <summary>
-        /// Gets the pages that may have catalog leaves within the provided commit timestamp bounds. The result is
-        /// sorted by commit timestamp.
+        /// Gets the pages that may have catalog leaves within the provided commit timestamp bounds.<br/>
+        /// The result is sorted by commit timestamp.
         /// </summary>
         /// <param name="catalogIndex">The catalog index to fetch pages from.</param>
         /// <param name="minCommitTimestamp">The exclusive lower time bound on <see cref="CatalogPageItem.CommitTimestamp"/>.</param>

--- a/src/BaGetter.Protocol/Extensions/HttpClientExtensions.cs
+++ b/src/BaGetter.Protocol/Extensions/HttpClientExtensions.cs
@@ -38,14 +38,13 @@ namespace BaGetter.Protocol
         }
 
         /// <summary>
-        /// Deserialize JSON content. If the HTTP response status code is 404,
-        /// returns the default value.
+        /// Deserialize JSON content.
         /// </summary>
         /// <typeparam name="TResult">The JSON type to deserialize.</typeparam>
         /// <param name="httpClient">The HTTP client that will perform the request.</param>
         /// <param name="requestUri">The request URI.</param>
         /// <param name="cancellationToken">A token to cancel the task.</param>
-        /// <returns>The JSON content, or, the default value if the HTTP response status code is 404.</returns>
+        /// <returns>The JSON content, or the default value if the HTTP response status code is 404.</returns>
         public static async Task<TResult> GetFromJsonOrDefaultAsync<TResult>(
             this HttpClient httpClient,
             string requestUri,

--- a/src/BaGetter.Protocol/Extensions/NuGetClientFactoryExtensions.cs
+++ b/src/BaGetter.Protocol/Extensions/NuGetClientFactoryExtensions.cs
@@ -6,7 +6,7 @@ namespace BaGetter.Protocol
     public static class NuGetClientFactoryExtensions
     {
         /// <summary>
-        /// Create a new <see cref="CatalogProcessor"/> to discover and download catalog leafs.
+        /// Create a new <see cref="CatalogProcessor"/> to discover and download catalog leafs.<br/>
         /// Leafs are processed by the <see cref="ICatalogLeafProcessor"/>.
         /// </summary>
         /// <param name="clientFactory">The factory used to create NuGet clients.</param>

--- a/src/BaGetter.Protocol/Models/AlternatePackage.cs
+++ b/src/BaGetter.Protocol/Models/AlternatePackage.cs
@@ -4,9 +4,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// The alternate package that should be used instead of a deprecated package.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#package-deprecation
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#package-deprecation"/></remarks>
     public class AlternatePackage
     {
         [JsonPropertyName("@id")]

--- a/src/BaGetter.Protocol/Models/AutocompleteResponse.cs
+++ b/src/BaGetter.Protocol/Models/AutocompleteResponse.cs
@@ -5,9 +5,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// The package ids that matched the autocomplete query.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/search-autocomplete-service-resource#search-for-package-ids
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/search-autocomplete-service-resource#search-for-package-ids"/></remarks>
     public class AutocompleteResponse
     {
         [JsonPropertyName("@context")]

--- a/src/BaGetter.Protocol/Models/CatalogIndex.cs
+++ b/src/BaGetter.Protocol/Models/CatalogIndex.cs
@@ -4,13 +4,14 @@ using System.Text.Json.Serialization;
 
 namespace BaGetter.Protocol.Models
 {
-    // This class is based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/CatalogIndex.cs
-
     /// <summary>
-    /// The catalog index is the entry point for the catalog resource.
+    /// The catalog index is the entry point for the catalog resource.<br/>
     /// Use this to discover catalog pages, which in turn can be used to discover catalog leafs.
     /// </summary>
-    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-index"/></remarks>
+    /// <remarks>
+    /// See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-index"/><br/>
+    /// Based off: <see href="https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/CatalogIndex.cs"/>
+    /// </remarks>
     public class CatalogIndex
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/CatalogIndex.cs
+++ b/src/BaGetter.Protocol/Models/CatalogIndex.cs
@@ -9,9 +9,8 @@ namespace BaGetter.Protocol.Models
     /// <summary>
     /// The catalog index is the entry point for the catalog resource.
     /// Use this to discover catalog pages, which in turn can be used to discover catalog leafs.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-index
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-index"/></remarks>
     public class CatalogIndex
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/CatalogLeaf.cs
+++ b/src/BaGetter.Protocol/Models/CatalogLeaf.cs
@@ -9,9 +9,8 @@ namespace BaGetter.Protocol.Models
     /// <summary>
     /// A catalog leaf. Represents a single package event.
     /// Leafs can be discovered from a <see cref="CatalogPage"/>.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf"/></remarks>
     public class CatalogLeaf : ICatalogLeafItem
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/CatalogLeaf.cs
+++ b/src/BaGetter.Protocol/Models/CatalogLeaf.cs
@@ -4,13 +4,14 @@ using System.Text.Json.Serialization;
 
 namespace BaGetter.Protocol.Models
 {
-    // This classed is based off: https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/CatalogLeaf.cs
-
     /// <summary>
-    /// A catalog leaf. Represents a single package event.
+    /// A catalog leaf. Represents a single package event.<br/>
     /// Leafs can be discovered from a <see cref="CatalogPage"/>.
     /// </summary>
-    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf"/></remarks>
+    /// <remarks>
+    /// See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf"/><br/>
+    /// Based off: <see href="https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/CatalogLeaf.cs"/>
+    /// </remarks>
     public class CatalogLeaf : ICatalogLeafItem
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/CatalogLeafItem.cs
+++ b/src/BaGetter.Protocol/Models/CatalogLeafItem.cs
@@ -7,9 +7,8 @@ namespace BaGetter.Protocol.Models
 
     /// <summary>
     /// An item in a <see cref="CatalogPage"/> that references a <see cref="CatalogLeaf"/>.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-item-object-in-a-page
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-item-object-in-a-page"/></remarks>
     public class CatalogLeafItem : ICatalogLeafItem
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/CatalogLeafItem.cs
+++ b/src/BaGetter.Protocol/Models/CatalogLeafItem.cs
@@ -3,12 +3,13 @@ using System.Text.Json.Serialization;
 
 namespace BaGetter.Protocol.Models
 {
-    // This class is based off https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/CatalogLeafItem.cs
-
     /// <summary>
     /// An item in a <see cref="CatalogPage"/> that references a <see cref="CatalogLeaf"/>.
     /// </summary>
-    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-item-object-in-a-page"/></remarks>
+    /// <remarks>
+    /// See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-item-object-in-a-page"/><br/>
+    /// Based off: <see href="https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/CatalogLeafItem.cs"/>
+    /// </remarks>
     public class CatalogLeafItem : ICatalogLeafItem
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/CatalogPage.cs
+++ b/src/BaGetter.Protocol/Models/CatalogPage.cs
@@ -9,9 +9,8 @@ namespace BaGetter.Protocol.Models
     /// <summary>
     /// A catalog page, used to discover catalog leafs.
     /// Pages can be discovered from a <see cref="CatalogIndex"/>.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-page
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-page"/></remarks>
     public class CatalogPage
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/CatalogPage.cs
+++ b/src/BaGetter.Protocol/Models/CatalogPage.cs
@@ -4,13 +4,14 @@ using System.Text.Json.Serialization;
 
 namespace BaGetter.Protocol.Models
 {
-    // This class is based off https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/CatalogPage.cs
-
     /// <summary>
-    /// A catalog page, used to discover catalog leafs.
+    /// A catalog page, used to discover catalog leafs.<br/>
     /// Pages can be discovered from a <see cref="CatalogIndex"/>.
     /// </summary>
-    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-page"/></remarks>
+    /// <remarks>
+    /// See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-page"/><br/>
+    /// Based off: <see href="https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/CatalogPage.cs"/>
+    /// </remarks>
     public class CatalogPage
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/CatalogPageItem.cs
+++ b/src/BaGetter.Protocol/Models/CatalogPageItem.cs
@@ -7,9 +7,8 @@ namespace BaGetter.Protocol.Models
 
     /// <summary>
     /// An item in the <see cref="CatalogIndex"/> that references a <see cref="CatalogPage"/>.
-    ///
-    /// See https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-page-object-in-the-index
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-page-object-in-the-index"/></remarks>
     public class CatalogPageItem
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/CatalogPageItem.cs
+++ b/src/BaGetter.Protocol/Models/CatalogPageItem.cs
@@ -3,12 +3,13 @@ using System.Text.Json.Serialization;
 
 namespace BaGetter.Protocol.Models
 {
-    // This class is based off https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/CatalogPageItem.cs
-
     /// <summary>
     /// An item in the <see cref="CatalogIndex"/> that references a <see cref="CatalogPage"/>.
     /// </summary>
-    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-page-object-in-the-index"/></remarks>
+    /// <remarks>
+    /// See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-page-object-in-the-index"/><br/>
+    /// Based off: <see href="https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/CatalogPageItem.cs"/>
+    /// </remarks>
     public class CatalogPageItem
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/DependencyGroupItem.cs
+++ b/src/BaGetter.Protocol/Models/DependencyGroupItem.cs
@@ -5,9 +5,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// The dependencies of the package for a specific target framework.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#package-dependency-group
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#package-dependency-group"/></remarks>
     public class DependencyGroupItem
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/DependencyItem.cs
+++ b/src/BaGetter.Protocol/Models/DependencyItem.cs
@@ -5,9 +5,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// Represents a package dependency.
-    ///
-    /// See https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#package-dependency
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#package-dependency"/></remarks>
     public class DependencyItem
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/ICatalogLeafItem.cs
+++ b/src/BaGetter.Protocol/Models/ICatalogLeafItem.cs
@@ -2,13 +2,14 @@ using System;
 
 namespace BaGetter.Protocol.Models
 {
-    // This class is based off https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/ICatalogLeafItem.cs
-
     /// <summary>
-    /// A catalog leaf. Represents a single package event.
+    /// A catalog leaf. Represents a single package event.<br/>
     /// Leafs can be discovered from a <see cref="CatalogPage"/>.
     /// </summary>
-    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf"/></remarks>
+    /// <remarks>
+    /// See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf"/><br/>
+    /// Based off: <see href="https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/ICatalogLeafItem.cs"/>
+    /// </remarks>
     public interface ICatalogLeafItem
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/ICatalogLeafItem.cs
+++ b/src/BaGetter.Protocol/Models/ICatalogLeafItem.cs
@@ -7,9 +7,8 @@ namespace BaGetter.Protocol.Models
     /// <summary>
     /// A catalog leaf. Represents a single package event.
     /// Leafs can be discovered from a <see cref="CatalogPage"/>.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf"/></remarks>
     public interface ICatalogLeafItem
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/PackageDeleteCatalogLeaf.cs
+++ b/src/BaGetter.Protocol/Models/PackageDeleteCatalogLeaf.cs
@@ -1,12 +1,13 @@
 namespace BaGetter.Protocol.Models
 {
-    // This class is based off https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/PackageDeleteCatalogLeaf.cs
-
     /// <summary>
-    /// A "package delete" catalog leaf. Represents a single package deletion event.
+    /// A "package delete" catalog leaf. Represents a single package deletion event.<br/>
     /// Leafs can be discovered from a <see cref="CatalogPage"/>.
     /// </summary>
-    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf"/></remarks>
+    /// <remarks>
+    /// See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf"/><br/>
+    /// Based off: <see href="https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/PackageDeleteCatalogLeaf.cs"/>
+    /// </remarks>    
     public class PackageDeleteCatalogLeaf : CatalogLeaf
     {
     }

--- a/src/BaGetter.Protocol/Models/PackageDeleteCatalogLeaf.cs
+++ b/src/BaGetter.Protocol/Models/PackageDeleteCatalogLeaf.cs
@@ -5,9 +5,8 @@ namespace BaGetter.Protocol.Models
     /// <summary>
     /// A "package delete" catalog leaf. Represents a single package deletion event.
     /// Leafs can be discovered from a <see cref="CatalogPage"/>.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf"/></remarks>
     public class PackageDeleteCatalogLeaf : CatalogLeaf
     {
     }

--- a/src/BaGetter.Protocol/Models/PackageDeprecation.cs
+++ b/src/BaGetter.Protocol/Models/PackageDeprecation.cs
@@ -5,9 +5,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// A package's metadata.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#package-deprecation
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#package-deprecation"/></remarks>
     public class PackageDeprecation
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/PackageDetailsCatalogLeaf.cs
+++ b/src/BaGetter.Protocol/Models/PackageDetailsCatalogLeaf.cs
@@ -4,13 +4,14 @@ using System.Text.Json.Serialization;
 
 namespace BaGetter.Protocol.Models
 {
-    // This class is based off https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/PackageDetailsCatalogLeaf.cs
-
     /// <summary>
-    /// A "package details" catalog leaf. Represents a single package create or update event.
+    /// A "package details" catalog leaf. Represents a single package create or update event.<br/>
     /// <see cref="PackageDetailsCatalogLeaf"/>s can be discovered from a <see cref="CatalogPage"/>.
     /// </summary>
-    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf"/></remarks>
+    /// <remarks>
+    /// See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf"/><br/>
+    /// Based off: <see href="https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/PackageDetailsCatalogLeaf.cs"/>
+    /// </remarks>
     public class PackageDetailsCatalogLeaf : CatalogLeaf
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/PackageDetailsCatalogLeaf.cs
+++ b/src/BaGetter.Protocol/Models/PackageDetailsCatalogLeaf.cs
@@ -4,14 +4,13 @@ using System.Text.Json.Serialization;
 
 namespace BaGetter.Protocol.Models
 {
-    /// This class is based off https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/PackageDetailsCatalogLeaf.cs
+    // This class is based off https://github.com/NuGet/NuGet.Services.Metadata/blob/64af0b59c5a79e0143f0808b39946df9f16cb2e7/src/NuGet.Protocol.Catalog/Models/PackageDetailsCatalogLeaf.cs
 
     /// <summary>
     /// A "package details" catalog leaf. Represents a single package create or update event.
     /// <see cref="PackageDetailsCatalogLeaf"/>s can be discovered from a <see cref="CatalogPage"/>.
-    /// 
-    /// See: https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf"/></remarks>
     public class PackageDetailsCatalogLeaf : CatalogLeaf
     {
         /// <summary>
@@ -59,8 +58,8 @@ namespace BaGetter.Protocol.Models
         /// <summary>
         /// Whether or not the package is prerelease. Can be detected from <see cref="CatalogLeaf.PackageVersion"/>.
         /// Note that the NuGet.org catalog had this wrong in some cases.
-        /// Example: https://api.nuget.org/v3/catalog0/data/2016.03.11.21.02.55/mvid.fody.2.json
         /// </summary>
+        /// <remarks>Example: <see href="https://api.nuget.org/v3/catalog0/data/2016.03.11.21.02.55/mvid.fody.2.json"/></remarks>
         [JsonPropertyName("isPrerelease")]
         public bool IsPrerelease { get; set; }
 
@@ -71,7 +70,7 @@ namespace BaGetter.Protocol.Models
         public string Language { get; set; }
 
         /// <summary>
-        /// THe URL to the package's license.
+        /// The URL to the package's license.
         /// </summary>
         [JsonPropertyName("licenseUrl")]
         public string LicenseUrl { get; set; }

--- a/src/BaGetter.Protocol/Models/PackageMetadata.cs
+++ b/src/BaGetter.Protocol/Models/PackageMetadata.cs
@@ -6,9 +6,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// A package's metadata.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#catalog-entry
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#catalog-entry"/></remarks>
     public class PackageMetadata
     {
         /// <summary>
@@ -103,7 +102,7 @@ namespace BaGetter.Protocol.Models
         public DateTimeOffset Published { get; set; }
 
         /// <summary>
-        /// If true, the package requires its license to be accepted.
+        /// If <see langword="true"/>, the package requires its license to be accepted.
         /// </summary>
         [JsonPropertyName("requireLicenseAcceptance")]
         public bool RequireLicenseAcceptance { get; set; }

--- a/src/BaGetter.Protocol/Models/PackageVersionsResponse.cs
+++ b/src/BaGetter.Protocol/Models/PackageVersionsResponse.cs
@@ -5,9 +5,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// The full list of versions for a single package.
-    ///
-    /// See https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource#enumerate-package-versions
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource#enumerate-package-versions"/></remarks>
     public class PackageVersionsResponse
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/RegistrationIndexPage.cs
+++ b/src/BaGetter.Protocol/Models/RegistrationIndexPage.cs
@@ -5,9 +5,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// The registration page object found in the registration index.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-page-object
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-page-object"/></remarks>
     public class RegistrationIndexPage
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/RegistrationIndexPageItem.cs
+++ b/src/BaGetter.Protocol/Models/RegistrationIndexPageItem.cs
@@ -4,9 +4,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// An item in the <see cref="CatalogIndex"/> that references a <see cref="CatalogLeaf"/>.
-    ///
-    /// See https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-leaf-object-in-a-page
     /// </summary>
+    /// <remarks>See <see href="https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-leaf-object-in-a-page"/></remarks>
     public class RegistrationIndexPageItem
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/RegistrationIndexResponse.cs
+++ b/src/BaGetter.Protocol/Models/RegistrationIndexResponse.cs
@@ -5,9 +5,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// The metadata for a package and all of its versions.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-index
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-index"/></remarks>
     public class RegistrationIndexResponse
     {
         public static readonly IReadOnlyList<string> DefaultType = new List<string>

--- a/src/BaGetter.Protocol/Models/RegistrationLeafResponse.cs
+++ b/src/BaGetter.Protocol/Models/RegistrationLeafResponse.cs
@@ -6,9 +6,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// The metadata for a single version of a package.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-leaf
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-leaf"/></remarks>
     public class RegistrationLeafResponse
     {
         public static readonly IReadOnlyList<string> DefaultType = new List<string>

--- a/src/BaGetter.Protocol/Models/RegistrationPageResponse.cs
+++ b/src/BaGetter.Protocol/Models/RegistrationPageResponse.cs
@@ -2,9 +2,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// A page of package metadata entries.
-    ///
-    /// See https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-page
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-page"/></remarks>
     public class RegistrationPageResponse : RegistrationIndexPage
     {
     }

--- a/src/BaGetter.Protocol/Models/SearchResponse.cs
+++ b/src/BaGetter.Protocol/Models/SearchResponse.cs
@@ -5,9 +5,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// The response to a search query.
-    ///
-    /// See https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#response
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#response"/></remarks>
     public class SearchResponse
     {
         [JsonPropertyName("@context")]

--- a/src/BaGetter.Protocol/Models/SearchResult.cs
+++ b/src/BaGetter.Protocol/Models/SearchResult.cs
@@ -6,9 +6,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// A package that matched a search query.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-result
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-result"/></remarks>
     public class SearchResult
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/SearchResultPackageType.cs
+++ b/src/BaGetter.Protocol/Models/SearchResultPackageType.cs
@@ -4,9 +4,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// A single package type from a <see cref="SearchResult"/>.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-result
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-result"/></remarks>
     public class SearchResultPackageType
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/SearchResultVersion.cs
+++ b/src/BaGetter.Protocol/Models/SearchResultVersion.cs
@@ -4,9 +4,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// A single version from a <see cref="SearchResult"/>.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-result
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-result"/></remarks>
     public class SearchResultVersion
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/ServiceIndexItem.cs
+++ b/src/BaGetter.Protocol/Models/ServiceIndexItem.cs
@@ -4,9 +4,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// A resource in the <see cref="ServiceIndexResponse"/>.
-    ///
-    /// See https://docs.microsoft.com/en-us/nuget/api/service-index#resources
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/service-index#resources"/></remarks>
     public class ServiceIndexItem
     {
         /// <summary>

--- a/src/BaGetter.Protocol/Models/ServiceIndexResponse.cs
+++ b/src/BaGetter.Protocol/Models/ServiceIndexResponse.cs
@@ -5,9 +5,8 @@ namespace BaGetter.Protocol.Models
 {
     /// <summary>
     /// The entry point for a NuGet package source used by the client to discover NuGet APIs.
-    ///
-    /// See https://docs.microsoft.com/en-us/nuget/api/overview
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/overview"/></remarks>
     public class ServiceIndexResponse
     {
         /// <summary>

--- a/src/BaGetter.Protocol/NuGetClientFactory.cs
+++ b/src/BaGetter.Protocol/NuGetClientFactory.cs
@@ -47,9 +47,8 @@ namespace BaGetter.Protocol
 
         /// <summary>
         /// Create a client to interact with the NuGet Service Index resource.
-        /// 
-        /// See https://docs.microsoft.com/en-us/nuget/api/service-index
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/service-index"/></remarks>
         /// <returns>A client to interact with the NuGet Service Index resource.</returns>
         public virtual IServiceIndexClient CreateServiceIndexClient()
         {
@@ -58,9 +57,8 @@ namespace BaGetter.Protocol
 
         /// <summary>
         /// Create a client to interact with the NuGet Package Content resource.
-        ///
-        /// See https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource"/></remarks>
         /// <returns>A client to interact with the NuGet Package Content resource.</returns>
         public virtual IPackageContentClient CreatePackageContentClient()
         {
@@ -69,9 +67,8 @@ namespace BaGetter.Protocol
 
         /// <summary>
         /// Create a client to interact with the NuGet Package Metadata resource.
-        /// 
-        /// See https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource"/></remarks>
         /// <returns>A client to interact with the NuGet Package Metadata resource.</returns>
         public virtual IPackageMetadataClient CreatePackageMetadataClient()
         {
@@ -80,9 +77,8 @@ namespace BaGetter.Protocol
 
         /// <summary>
         /// Create a client to interact with the NuGet Search resource.
-        /// 
-        /// See https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource"/></remarks>
         /// <returns>A client to interact with the NuGet Search resource.</returns>
         public virtual ISearchClient CreateSearchClient()
         {
@@ -91,9 +87,8 @@ namespace BaGetter.Protocol
 
         /// <summary>
         /// Create a client to interact with the NuGet Autocomplete resource.
-        /// 
-        /// See https://docs.microsoft.com/en-us/nuget/api/search-autocomplete-service-resource
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/search-autocomplete-service-resource"/></remarks>
         /// <returns>A client to interact with the NuGet Autocomplete resource.</returns>
         public virtual IAutocompleteClient CreateAutocompleteClient()
         {
@@ -102,9 +97,8 @@ namespace BaGetter.Protocol
 
         /// <summary>
         /// Create a client to interact with the NuGet catalog resource.
-        /// 
-        /// See https://docs.microsoft.com/en-us/nuget/api/catalog-resource
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/catalog-resource"/></remarks>
         /// <returns>A client to interact with the Catalog resource.</returns>
         public virtual ICatalogClient CreateCatalogClient()
         {

--- a/src/BaGetter.Protocol/PackageContent/IPackageContentClient.cs
+++ b/src/BaGetter.Protocol/PackageContent/IPackageContentClient.cs
@@ -8,15 +8,14 @@ namespace BaGetter.Protocol
 {
     /// <summary>
     /// The Package Content resource, used to download NuGet packages and to fetch other metadata.
-    /// 
-    /// See: https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource"/></remarks>
     public interface IPackageContentClient
     {
         /// <summary>
         /// Get a package's versions, or null if the package does not exist.
-        /// See: https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource#enumerate-package-versions
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource#enumerate-package-versions"/></remarks>
         /// <param name="packageId">The package ID.</param>
         /// <param name="cancellationToken">A token to cancel the task.</param>
         /// <returns>The package's versions, or null if the package does not exist.</returns>
@@ -26,8 +25,8 @@ namespace BaGetter.Protocol
 
         /// <summary>
         /// Download a package, or null if the package does not exist.
-        /// See: https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource#download-package-content-nupkg
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource#download-package-content-nupkg"/></remarks>
         /// <param name="packageId">The package ID.</param>
         /// <param name="packageVersion">The package's version.</param>
         /// <param name="cancellationToken">A token to cancel the task.</param>
@@ -41,8 +40,8 @@ namespace BaGetter.Protocol
 
         /// <summary>
         /// Download a package's manifest (nuspec), or null if the package does not exist.
-        /// See: https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource#download-package-manifest-nuspec
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource#download-package-manifest-nuspec"/></remarks>
         /// <param name="packageId">The package id.</param>
         /// <param name="packageVersion">The package's version.</param>
         /// <param name="cancellationToken">A token to cancel the task.</param>

--- a/src/BaGetter.Protocol/PackageMetadata/IPackageMetadataClient.cs
+++ b/src/BaGetter.Protocol/PackageMetadata/IPackageMetadataClient.cs
@@ -6,15 +6,14 @@ namespace BaGetter.Protocol
 {
     /// <summary>
     /// The Package Metadata client, used to fetch packages' metadata.
-    ///
-    /// See https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource"/></remarks>
     public interface IPackageMetadataClient
     {
         /// <summary>
         /// Attempt to get a package's registration index, if it exists.
-        /// See: https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-page
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-page"/></remarks>
         /// <param name="packageId">The package's ID.</param>
         /// <param name="cancellationToken">A token to cancel the task.</param>
         /// <returns>The package's registration index, or null if the package does not exist</returns>
@@ -22,8 +21,8 @@ namespace BaGetter.Protocol
 
         /// <summary>
         /// Get a page that was linked from the package's registration index.
-        /// See: https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-page
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registration-page"/></remarks>
         /// <param name="pageUrl">The URL of the page, from the <see cref="RegistrationIndexResponse"/>.</param>
         /// <param name="cancellationToken">A token to cancel the task.</param>
         /// <returns>The registration index page.</returns>

--- a/src/BaGetter.Protocol/Search/IAutocompleteClient.cs
+++ b/src/BaGetter.Protocol/Search/IAutocompleteClient.cs
@@ -6,15 +6,14 @@ namespace BaGetter.Protocol
 {
     /// <summary>
     /// The client used to search for packages.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/search-autocomplete-service-resource
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/search-autocomplete-service-resource"/></remarks>
     public interface IAutocompleteClient
     {
         /// <summary>
-        /// Perform an autocomplete query on package IDs.
-        /// See: https://docs.microsoft.com/en-us/nuget/api/search-autocomplete-service-resource#search-for-package-ids
+        /// Perform an autocomplete query on package IDs.        
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/search-autocomplete-service-resource#search-for-package-ids"/></remarks>
         /// <param name="query">The autocomplete query.</param>
         /// <param name="skip">How many results to skip.</param>
         /// <param name="take">How many results to return.</param>
@@ -32,8 +31,8 @@ namespace BaGetter.Protocol
 
         /// <summary>
         /// Enumerate listed package versions.
-        /// See: https://docs.microsoft.com/en-us/nuget/api/search-autocomplete-service-resource#enumerate-package-versions
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/search-autocomplete-service-resource#enumerate-package-versions"/></remarks>
         /// <param name="packageId">The package ID.</param>
         /// <param name="includePrerelease">Whether pre-release packages should be returned.</param>
         /// <param name="includeSemVer2">Whether packages that require SemVer 2.0.0 compatibility should be returned.</param>

--- a/src/BaGetter.Protocol/Search/ISearchClient.cs
+++ b/src/BaGetter.Protocol/Search/ISearchClient.cs
@@ -6,15 +6,14 @@ namespace BaGetter.Protocol
 {
     /// <summary>
     /// The client used to search for packages.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource"/></remarks>
     public interface ISearchClient
     {
         /// <summary>
         /// Perform a search query.
-        /// See: https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-for-packages
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-for-packages"/></remarks>
         /// <param name="query">The search query.</param>
         /// <param name="skip">How many results to skip.</param>
         /// <param name="take">How many results to return.</param>

--- a/src/BaGetter.Protocol/Search/RawAutocompleteClient.cs
+++ b/src/BaGetter.Protocol/Search/RawAutocompleteClient.cs
@@ -8,9 +8,8 @@ namespace BaGetter.Protocol.Internal
 {
     /// <summary>
     /// The client used to search for packages.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/search-autocomplete-service-resource
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/search-autocomplete-service-resource"/></remarks>
     public class RawAutocompleteClient : IAutocompleteClient
     {
         private readonly HttpClient _httpClient;

--- a/src/BaGetter.Protocol/Search/RawSearchClient.cs
+++ b/src/BaGetter.Protocol/Search/RawSearchClient.cs
@@ -10,9 +10,8 @@ namespace BaGetter.Protocol.Internal
 {
     /// <summary>
     /// The client used to search for packages.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource"/></remarks>
     public class RawSearchClient : ISearchClient
     {
         private readonly HttpClient _httpClient;

--- a/src/BaGetter.Protocol/ServiceIndex/IServiceIndexClient.cs
+++ b/src/BaGetter.Protocol/ServiceIndex/IServiceIndexClient.cs
@@ -6,15 +6,14 @@ namespace BaGetter.Protocol
 {
     /// <summary>
     /// The NuGet Service Index client, used to discover other resources.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/service-index
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/service-index"/></remarks>
     public interface IServiceIndexClient
     {
         /// <summary>
         /// Get the resources available on this package feed.
-        /// See: https://docs.microsoft.com/en-us/nuget/api/service-index#resources
         /// </summary>
+        /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/service-index#resources"/></remarks>
         /// <returns>The resources available on this package feed.</returns>
         Task<ServiceIndexResponse> GetAsync(CancellationToken cancellationToken = default);
     }

--- a/src/BaGetter.Protocol/ServiceIndex/RawServiceIndexClient.cs
+++ b/src/BaGetter.Protocol/ServiceIndex/RawServiceIndexClient.cs
@@ -8,9 +8,8 @@ namespace BaGetter.Protocol.Internal
 {
     /// <summary>
     /// The NuGet Service Index client, used to discover other resources.
-    /// 
-    /// See https://docs.microsoft.com/en-us/nuget/api/service-index
     /// </summary>
+    /// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/service-index"/></remarks>
     public class RawServiceIndexClient : IServiceIndexClient
     {
         private readonly HttpClient _httpClient;


### PR DESCRIPTION
This PR alters some of the xml comments. The main reason is to change the display and functionality inside of VisualStudio.
Also some "based off" comments were changed to align with comments in other files.

### before
![doc_link_before](https://github.com/bagetter/BaGetter/assets/6222752/29d9201c-fdcc-402a-9e17-2d6b261e59c1)

### after
![doc_link_after](https://github.com/bagetter/BaGetter/assets/6222752/4cbaaf44-cd49-42b2-83ae-a754e2c17c45)
