### PR TITLE
Add hideable sidebar and broken anchor checker to documentation

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -52,6 +52,11 @@ const config: Config = {
   ],
 
   themeConfig: {
+    docs: {
+      sidebar: {
+        hideable: true,
+      }
+    },
     // Replace with your project's social card
     image: 'img/docusaurus-social-card.jpg',
     navbar: {

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -22,7 +22,8 @@ const config: Config = {
   trailingSlash: false,
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenMarkdownLinks: 'throw',
+  onBrokenAnchors: 'throw',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
This PR enables a new feature for the documentation and also lets the build process fail, if there are any broken links or anchors inside the Markdown files.

- hideable side bar (https://docusaurus.io/docs/sidebar#hideable-sidebar)
  > ... you can make the entire sidebar hideable, allowing users to better focus on the content. This is especially useful when content is consumed on medium-sized screens (e.g. tablets).

  ![sidebar](https://github.com/bagetter/BaGetter/assets/6222752/d0246e35-d033-46b0-9b8a-29fbb7da2e52)
- broken anchors checker (https://docusaurus.io/blog/releases/3.1#broken-anchors-checker and https://docusaurus.io/docs/api/docusaurus-config#onBrokenAnchors)
  > ... We recommend to turn it to throw and fail your CI builds instead of deploying broken anchors to productions.

