### PR TITLE
Add support for embedded license file

### DIFF
--- a/src/BaGetter.Core/Content/DefaultPackageContentService.cs
+++ b/src/BaGetter.Core/Content/DefaultPackageContentService.cs
@@ -88,4 +88,15 @@ public class DefaultPackageContentService : IPackageContentService
 
         return await _storage.GetIconStreamAsync(id, version, cancellationToken);
     }
+
+    public async Task<Stream> GetPackageLicenseStreamOrNullAsync(string id, NuGetVersion version, CancellationToken cancellationToken = default)
+    {
+        var package = await _packages.FindPackageOrNullAsync(id, version, cancellationToken);
+        if (package == null || !package.HasEmbeddedLicense)
+        {
+            return null;
+        }
+
+        return await _storage.GetLicenseStreamAsync(id, version, package.LicenseFormatIsMarkdown, cancellationToken);
+    }
 }

--- a/src/BaGetter.Core/Content/IPackageContentService.cs
+++ b/src/BaGetter.Core/Content/IPackageContentService.cs
@@ -81,4 +81,13 @@ public interface IPackageContentService
         string id,
         NuGetVersion version,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The package license if the license is an embedded license, or null if the license is a URL or expression.
+    /// </summary>
+    /// <param name="id">The package id.</param>
+    /// <param name="version">The package's version.</param>
+    /// <param name="cancellationToken">A token to cancel the task.</param>
+    /// <returns>The package's license stream, or null if the package license does not exist, or the license type is URL or expression.</returns>
+    Task<Stream> GetPackageLicenseStreamOrNullAsync(string id, NuGetVersion version, CancellationToken cancellationToken);
 }

--- a/src/BaGetter.Core/Entities/Package.cs
+++ b/src/BaGetter.Core/Entities/Package.cs
@@ -4,7 +4,10 @@ using NuGet.Versioning;
 
 namespace BaGetter.Core;
 
-// See NuGetGallery's: https://github.com/NuGet/NuGetGallery/blob/master/src/NuGetGallery.Core/Entities/Package.cs
+/// <remarks>
+/// See: <see href="https://github.com/NuGet/NuGetGallery/blob/master/src/NuGetGallery.Core/Entities/Package.cs"/><br/>
+/// Newer version: <see href="https://github.com/NuGet/NuGetGallery/blob/main/src/NuGet.Services.Entities/Package.cs"/>
+/// </remarks>
 public class Package
 {
     public int Key { get; set; }
@@ -34,10 +37,22 @@ public class Package
     public string Description { get; set; }
     public long Downloads { get; set; }
     public bool HasReadme { get; set; }
+    /// <summary>
+    /// Indicates if the icon is embedded in the package.
+    /// </summary>
     public bool HasEmbeddedIcon { get; set; }
+    /// <summary>
+    /// Indicates if the license is embedded in the package.
+    /// </summary>
+    public bool HasEmbeddedLicense { get; set; }
     public bool IsPrerelease { get; set; }
     public string ReleaseNotes { get; set; }
     public string Language { get; set; }
+    /// <summary>
+    /// Indicates if the license format is Markdown.
+    /// </summary>
+    /// <value><c>true</c> if Markdown, <c>false</c> otherwise.</value>
+    public bool LicenseFormatIsMarkdown { get; set; }
     public bool Listed { get; set; }
     public string MinClientVersion { get; set; }
     public DateTime Published { get; set; }

--- a/src/BaGetter.Core/IUrlGenerator.cs
+++ b/src/BaGetter.Core/IUrlGenerator.cs
@@ -101,4 +101,12 @@ public interface IUrlGenerator
     /// <param name="id">The package's ID</param>
     /// <param name="version">The package's version</param>
     string GetPackageIconDownloadUrl(string id, NuGetVersion version);
+
+    /// <summary>
+    /// Get the URL to download a package's license.
+    /// </summary>
+    /// <param name="id">The package's ID</param>
+    /// <param name="version">The package's version</param>
+    /// <param name="licenseFormatIsMarkdown">Is the format of the license Markdown?</param>
+    string GetPackageLicenseDownloadUrl(string id, NuGetVersion version, bool licenseFormatIsMarkdown);
 }

--- a/src/BaGetter.Core/Indexing/PackageIndexingService.cs
+++ b/src/BaGetter.Core/Indexing/PackageIndexingService.cs
@@ -40,6 +40,7 @@ public class PackageIndexingService : IPackageIndexingService
         Stream nuspecStream;
         Stream readmeStream;
         Stream iconStream;
+        Stream licenseStream;
 
         try
         {
@@ -69,6 +70,16 @@ public class PackageIndexingService : IPackageIndexingService
                 else
                 {
                     iconStream = null;
+                }
+
+                if (package.HasEmbeddedLicense)
+                {
+                    licenseStream = await packageReader.GetLicenseAsync(cancellationToken);
+                    licenseStream = await licenseStream.AsTemporaryFileStreamAsync(cancellationToken);
+                }
+                else
+                {
+                    licenseStream = null;
                 }
             }
         }
@@ -108,6 +119,7 @@ public class PackageIndexingService : IPackageIndexingService
                 nuspecStream,
                 readmeStream,
                 iconStream,
+                licenseStream,
                 cancellationToken);
         }
         catch (Exception e)

--- a/src/BaGetter.Core/Metadata/RegistrationBuilder.cs
+++ b/src/BaGetter.Core/Metadata/RegistrationBuilder.cs
@@ -74,7 +74,9 @@ public class RegistrationBuilder
                     ? _url.GetPackageIconDownloadUrl(package.Id, package.Version)
                     : package.IconUrlString,
                 Language = package.Language,
-                LicenseUrl = package.LicenseUrlString,
+                LicenseUrl = package.HasEmbeddedLicense
+                    ? _url.GetPackageLicenseDownloadUrl(package.Id, package.Version, package.LicenseFormatIsMarkdown)
+                    : package.LicenseUrlString,
                 Listed = package.Listed,
                 MinClientVersion = package.MinClientVersion,
                 ReleaseNotes = package.ReleaseNotes,

--- a/src/BaGetter.Core/Search/SearchResponseBuilder.cs
+++ b/src/BaGetter.Core/Search/SearchResponseBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using BaGetter.Protocol.Models;
@@ -25,6 +25,9 @@ public class SearchResponseBuilder : ISearchResponseBuilder
             var iconUrl = latest.HasEmbeddedIcon
                 ? _url.GetPackageIconDownloadUrl(latest.Id, latest.Version)
                 : latest.IconUrlString;
+            var licenseUrl = latest.HasEmbeddedLicense
+                ? _url.GetPackageLicenseDownloadUrl(latest.Id, latest.Version, latest.LicenseFormatIsMarkdown)
+                : latest.LicenseUrlString;
 
             result.Add(new SearchResult
             {
@@ -33,7 +36,7 @@ public class SearchResponseBuilder : ISearchResponseBuilder
                 Description = latest.Description,
                 Authors = latest.Authors,
                 IconUrl = iconUrl,
-                LicenseUrl = latest.LicenseUrlString,
+                LicenseUrl = licenseUrl,
                 ProjectUrl = latest.ProjectUrlString,
                 RegistrationIndexUrl = _url.GetRegistrationIndexUrl(latest.Id),
                 Summary = latest.Summary,

--- a/src/BaGetter.Core/Storage/IPackageStorageService.cs
+++ b/src/BaGetter.Core/Storage/IPackageStorageService.cs
@@ -6,8 +6,8 @@ using NuGet.Versioning;
 namespace BaGetter.Core;
 
 /// <summary>
-/// Stores packages' content. Packages' state are stored by the
-/// <see cref="IPackageDatabase"/>.
+/// Stores packages' content.<br/>
+/// Packages' state are stored by the <see cref="IPackageDatabase"/>.
 /// </summary>
 public interface IPackageStorageService
 {
@@ -20,6 +20,7 @@ public interface IPackageStorageService
     /// <param name="nuspecStream">The package's nuspec stream.</param>
     /// <param name="readmeStream">The package's readme stream, or null if none.</param>
     /// <param name="iconStream">The package's icon stream, or null if none.</param>
+    /// <param name="licenseStream">The package's license stream, or null if none.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     Task SavePackageContentAsync(
@@ -28,6 +29,7 @@ public interface IPackageStorageService
         Stream nuspecStream,
         Stream readmeStream,
         Stream iconStream,
+        Stream licenseStream,
         CancellationToken cancellationToken);
 
     /// <summary>
@@ -57,7 +59,24 @@ public interface IPackageStorageService
     /// <returns>The package's readme stream.</returns>
     Task<Stream> GetReadmeStreamAsync(string id, NuGetVersion version, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Retrieve a package's icon stream if the icon is an embedded file.
+    /// </summary>
+    /// <param name="id">The package's id.</param>
+    /// <param name="version">The package's version.</param>    
+    /// <param name="cancellationToken"></param>
+    /// <returns>The package's icon stream.</returns>
     Task<Stream> GetIconStreamAsync(string id, NuGetVersion version, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Retrieve a package's license stream if the license is an embedded file.
+    /// </summary>
+    /// <param name="id">The package's id.</param>
+    /// <param name="version">The package's version.</param>
+    /// <param name="licenseFormatIsMarkdown">Is the format of the license Markdown?</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>The package's license stream.</returns>
+    Task<Stream> GetLicenseStreamAsync(string id, NuGetVersion version, bool licenseFormatIsMarkdown, CancellationToken cancellationToken);
 
     /// <summary>
     /// Remove a package's content from storage. This operation SHOULD succeed

--- a/src/BaGetter.Web/BaGetterEndpointBuilder.cs
+++ b/src/BaGetter.Web/BaGetterEndpointBuilder.cs
@@ -127,5 +127,15 @@ public class BaGetterEndpointBuilder
             name: Routes.PackageDownloadIconRouteName,
             pattern: "v3/package/{id}/{version}/icon",
             defaults: new { controller = "PackageContent", action = "DownloadIcon" });
+
+        endpoints.MapControllerRoute(
+            name: Routes.PackageDownloadLicenseTextRouteName,
+            pattern: "v3/package/{id}/{version}/license.txt",
+            defaults: new { controller = "PackageContent", action = "DownloadLicense" });
+
+        endpoints.MapControllerRoute(
+            name: Routes.PackageDownloadLicenseMarkdownRouteName,
+            pattern: "v3/package/{id}/{version}/license.md",
+            defaults: new { controller = "PackageContent", action = "DownloadLicense" });
     }
 }

--- a/src/BaGetter.Web/BaGetterUrlGenerator.cs
+++ b/src/BaGetter.Web/BaGetterUrlGenerator.cs
@@ -149,6 +149,22 @@ public class BaGetterUrlGenerator : IUrlGenerator
             });
     }
 
+    public string GetPackageLicenseDownloadUrl(string id, NuGetVersion version, bool licenseFormatIsMarkdown)
+    {
+        id = id.ToLowerInvariant();
+        var versionString = version.ToNormalizedString().ToLowerInvariant();
+        var routeName = licenseFormatIsMarkdown ? Routes.PackageDownloadLicenseMarkdownRouteName : Routes.PackageDownloadLicenseTextRouteName;
+
+        return _linkGenerator.GetUriByRouteValues(
+            _httpContextAccessor.HttpContext,
+            routeName,
+            values: new
+            {
+                Id = id,
+                Version = versionString
+            });
+    }
+
     private string AbsoluteUrl(string relativePath)
     {
         var request = _httpContextAccessor.HttpContext.Request;

--- a/src/BaGetter.Web/Controllers/PackageContentController.cs
+++ b/src/BaGetter.Web/Controllers/PackageContentController.cs
@@ -10,8 +10,8 @@ namespace BaGetter.Web;
 
 /// <summary>
 /// The Package Content resource, used to download content from packages.
-/// See: https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource
 /// </summary>
+/// <remarks>See: <see href="https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource"/></remarks>
 public class PackageContentController : Controller
 {
     private readonly IPackageContentService _content;
@@ -94,5 +94,21 @@ public class PackageContentController : Controller
         }
 
         return File(iconStream, "image/xyz");
+    }
+
+    public async Task<IActionResult> DownloadLicenseAsync(string id, string version, CancellationToken cancellationToken)
+    {
+        if (!NuGetVersion.TryParse(version, out var nugetVersion))
+        {
+            return NotFound();
+        }
+
+        var licenseStream = await _content.GetPackageLicenseStreamOrNullAsync(id, nugetVersion, cancellationToken);
+        if (licenseStream == null)
+        {
+            return NotFound();
+        }
+
+        return File(licenseStream, "image/plain");
     }
 }

--- a/src/BaGetter.Web/Pages/Package.cshtml.cs
+++ b/src/BaGetter.Web/Pages/Package.cshtml.cs
@@ -106,7 +106,9 @@ public class PackageModel : PageModel
         IconUrl = Package.HasEmbeddedIcon
             ? _url.GetPackageIconDownloadUrl(Package.Id, packageVersion)
             : Package.IconUrlString;
-        LicenseUrl = Package.LicenseUrlString;
+        LicenseUrl = Package.HasEmbeddedLicense
+            ? _url.GetPackageLicenseDownloadUrl(Package.Id, packageVersion, Package.LicenseFormatIsMarkdown)
+            : Package.LicenseUrlString;
         PackageDownloadUrl = _url.GetPackageDownloadUrl(Package.Id, packageVersion);
     }
 

--- a/src/BaGetter.Web/Routes.cs
+++ b/src/BaGetter.Web/Routes.cs
@@ -17,6 +17,8 @@ public class Routes
     public const string PackageDownloadManifestRouteName = "package-download-manifest";
     public const string PackageDownloadReadmeRouteName = "package-download-readme";
     public const string PackageDownloadIconRouteName = "package-download-icon";
+    public const string PackageDownloadLicenseMarkdownRouteName = "package-download-license-md";
+    public const string PackageDownloadLicenseTextRouteName = "package-download-license-txt";
     public const string SymbolDownloadRouteName = "symbol-download";
     public const string PrefixedSymbolDownloadRouteName = "prefixed-symbol-download";
 }

--- a/tests/BaGetter.Core.Tests/Services/PackageStorageServiceTests.cs
+++ b/tests/BaGetter.Core.Tests/Services/PackageStorageServiceTests.cs
@@ -24,7 +24,8 @@ public class PackageStorageServiceTests
                     packageStream: Stream.Null,
                     nuspecStream: Stream.Null,
                     readmeStream: Stream.Null,
-                    iconStream: Stream.Null));
+                    iconStream: Stream.Null,
+                    licenseStream: Stream.Null));
         }
 
         [Fact]
@@ -36,7 +37,8 @@ public class PackageStorageServiceTests
                     packageStream: null,
                     nuspecStream: Stream.Null,
                     readmeStream: Stream.Null,
-                    iconStream: Stream.Null));
+                    iconStream: Stream.Null,
+                    licenseStream: Stream.Null));
         }
 
         [Fact]
@@ -48,7 +50,8 @@ public class PackageStorageServiceTests
                     packageStream: Stream.Null,
                     nuspecStream: null,
                     readmeStream: Stream.Null,
-                    iconStream: Stream.Null));
+                    iconStream: Stream.Null,
+                    licenseStream: Stream.Null));
         }
 
         [Fact]
@@ -61,6 +64,7 @@ public class PackageStorageServiceTests
             using (var nuspecStream = StringStream("My nuspec"))
             using (var readmeStream = StringStream("My readme"))
             using (var iconStream = StringStream("My icon"))
+            using (var licenseStream = StringStream("My license"))
             {
                 // Act
                 await _target.SavePackageContentAsync(
@@ -68,7 +72,8 @@ public class PackageStorageServiceTests
                     packageStream: packageStream,
                     nuspecStream: nuspecStream,
                     readmeStream: readmeStream,
-                    iconStream: iconStream);
+                    iconStream: iconStream,
+                    licenseStream: licenseStream);
 
                 // Assert
                 Assert.True(_puts.ContainsKey(PackagePath));
@@ -86,6 +91,10 @@ public class PackageStorageServiceTests
                 Assert.True(_puts.ContainsKey(IconPath));
                 Assert.Equal("My icon", await ToStringAsync(_puts[IconPath].Content));
                 Assert.Equal("image/xyz", _puts[IconPath].ContentType);
+
+                Assert.True(_puts.ContainsKey(LicensePath));
+                Assert.Equal("My license", await ToStringAsync(_puts[LicensePath].Content));
+                Assert.Equal("text/plain", _puts[LicensePath].ContentType);
             }
         }
 
@@ -104,7 +113,8 @@ public class PackageStorageServiceTests
                     packageStream: packageStream,
                     nuspecStream: nuspecStream,
                     readmeStream: null,
-                    iconStream: null);
+                    iconStream: null,
+                    licenseStream: null);
             }
 
             // Assert
@@ -122,6 +132,7 @@ public class PackageStorageServiceTests
             using (var nuspecStream = StringStream("My nuspec"))
             using (var readmeStream = StringStream("My readme"))
             using (var iconStream = StringStream("My icon"))
+            using (var licenseStream = StringStream("My license"))
             {
                 // Act
                 await _target.SavePackageContentAsync(
@@ -129,7 +140,8 @@ public class PackageStorageServiceTests
                     packageStream: packageStream,
                     nuspecStream: nuspecStream,
                     readmeStream: readmeStream,
-                    iconStream: iconStream);
+                    iconStream: iconStream,
+                    licenseStream: licenseStream);
             }
 
             // Assert
@@ -148,13 +160,15 @@ public class PackageStorageServiceTests
             using (var nuspecStream = StringStream("My nuspec"))
             using (var readmeStream = StringStream("My readme"))
             using (var iconStream = StringStream("My icon"))
+            using (var licenseStream = StringStream("My license"))
             {
                 await _target.SavePackageContentAsync(
                     _package,
                     packageStream: packageStream,
                     nuspecStream: nuspecStream,
                     readmeStream: readmeStream,
-                    iconStream: iconStream);
+                    iconStream: iconStream,
+                    licenseStream: licenseStream);
 
                 // Assert
                 Assert.True(_puts.ContainsKey(PackagePath));
@@ -172,6 +186,10 @@ public class PackageStorageServiceTests
                 Assert.True(_puts.ContainsKey(IconPath));
                 Assert.Equal("My icon", await ToStringAsync(_puts[IconPath].Content));
                 Assert.Equal("image/xyz", _puts[IconPath].ContentType);
+
+                Assert.True(_puts.ContainsKey(LicensePath));
+                Assert.Equal("My license", await ToStringAsync(_puts[LicensePath].Content));
+                Assert.Equal("text/plain", _puts[LicensePath].ContentType);
             }
         }
 
@@ -185,6 +203,7 @@ public class PackageStorageServiceTests
             using (var nuspecStream = StringStream("My nuspec"))
             using (var readmeStream = StringStream("My readme"))
             using (var iconStream = StringStream("My icon"))
+            using (var licenseStream = StringStream("My license"))
             {
                 // Act
                 await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -193,7 +212,8 @@ public class PackageStorageServiceTests
                         packageStream: packageStream,
                         nuspecStream: nuspecStream,
                         readmeStream: readmeStream,
-                        iconStream: iconStream));
+                        iconStream: iconStream,
+                        licenseStream: licenseStream));
             }
         }
     }
@@ -352,6 +372,7 @@ public class PackageStorageServiceTests
         protected string NuspecPath => Path.Combine("packages", "my.package", "1.2.3", "my.package.nuspec");
         protected string ReadmePath => Path.Combine("packages", "my.package", "1.2.3", "readme");
         protected string IconPath => Path.Combine("packages", "my.package", "1.2.3", "icon");
+        protected string LicensePath => Path.Combine("packages", "my.package", "1.2.3", "license.txt");
 
         protected Stream StringStream(string input)
         {

--- a/tests/BaGetter.Core.Tests/Upstream/V3UpstreamClientTests.cs
+++ b/tests/BaGetter.Core.Tests/Upstream/V3UpstreamClientTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -150,10 +150,12 @@ public class V3UpstreamClientTests
             var package = Assert.Single(result);
 
             Assert.Equal("Foo", package.Id);
-            Assert.Equal(new[] { "Author1", "Author2"}, package.Authors);
+            Assert.Equal(new[] { "Author1", "Author2" }, package.Authors);
             Assert.Equal("Description", package.Description);
             Assert.False(package.HasReadme);
             Assert.False(package.HasEmbeddedIcon);
+            Assert.False(package.HasEmbeddedLicense);
+            Assert.False(package.LicenseFormatIsMarkdown);
             Assert.True(package.IsPrerelease);
             Assert.Null(package.ReleaseNotes);
             Assert.Equal("Language", package.Language);


### PR DESCRIPTION
This PR adds support for downloading an embedded license file and is based on [this PR](https://github.com/loic-sharma/BaGet/pull/793) by @rbdavison.

### current situation

If a package has an embedded license file, the link on the package details page is https://aka.ms/deprecateLicenseUrl which states:

> Some NuGet clients and NuGet feeds might not be able to surface licensing information.
> To maintain backward compatibility in such cases, the license URL points to this document about how to retrieve the license information.

So a user has to do **multiple manual steps** to download the license.

### situation after this PR

The package details page has a direct link to the license.
So a user has to do **one click** to download the license.

### Todo:

- [ ] add Migrations for new features
- [ ] maybe add some more unit tests
- [ ] maybe add some integration tests

### more information:

- https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file
- https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg
- https://learn.microsoft.com/en-us/nuget/reference/nuspec#license
- https://github.com/NuGet/Samples/tree/main/PackageLicenseFileExample
- https://learn.microsoft.com/en-us/nuget/consume-packages/finding-and-choosing-packages#retrieve-license-information
- https://github.com/NuGet/Samples/tree/main/PackageIconExample

Testdata I used/created: [testdata.zip](https://github.com/bagetter/BaGetter/files/14310441/testdata.zip)
