### PR TITLE
Adjust color of copy and search buttons

### DIFF
--- a/src/BaGetter.Web/wwwroot/css/site.css
+++ b/src/BaGetter.Web/wwwroot/css/site.css
@@ -1,4 +1,4 @@
-﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
 for details on configuring this project to bundle and minify static web assets. */
 
 /* Layout
@@ -145,6 +145,7 @@ h4 {
 .search-container button:hover {
   background-color: #a56000;
   border-color: #814b00;
+  color: #fff;
 }
 
 .link-button {
@@ -314,15 +315,33 @@ h4 {
 }
 
 .tabbed-info .content .copy-button button {
-    height: 100%;
-    min-height: 42px;
-    vertical-align: baseline;
-    border-radius: 0px;
+  height: 100%;
+  min-height: 42px;
+  vertical-align: baseline;
+  border-radius: 0px;  
 }
 
-/* Package page
+.copy-button button {
+  color: #fff;
+  background-color: #d87e00;
+  border-color: #bf6f00;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.copy-button button:active,
+.copy-button button:active:focus,
+.copy-button button:active:hover,
+.copy-button button:focus,
+.copy-button button:hover {
+  background-color: #a56000;
+  border-color: #814b00;
+  color: #fff;
+}
+
+    /* Package page
 -------------------------------------------------- */
-.display-package .package-icon {
+    .display-package .package-icon {
     margin-top: 15px;
 }
 


### PR DESCRIPTION
This PR adjusts the color of the copy and search buttons to be the same (like on the official gallery) and fixes the hover color of the search button (like on the official gallery).

### **before**
![color_before](https://github.com/bagetter/BaGetter/assets/6222752/edb2a352-91ad-4b61-a9d4-a6fb413383d6)

### **after**
![color_after](https://github.com/bagetter/BaGetter/assets/6222752/e9699ebc-c9e3-4902-b6e8-23ca5a964493)
