### PR TITLE
Parse release notes as Markdown

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
-    <PackageVersion Include="Markdig" Version="0.33.0" />
+    <PackageVersion Include="Markdig" Version="0.35.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="[5.1.3,)" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />

--- a/src/BaGetter.Web/Pages/Package.cshtml
+++ b/src/BaGetter.Web/Pages/Package.cshtml
@@ -119,7 +119,7 @@ else
             @if (!string.IsNullOrEmpty(Model.Package.ReleaseNotes))
             {
                 ExpandableSection("Release Notes", expanded: false,
-                    @<div class="package-release-notes">@Model.Package.ReleaseNotes</div>);
+                    @<div class="package-release-notes">@Model.ParsedReleaseNotes</div>);
             }
 
             @{ ExpandableSection(

--- a/src/BaGetter.Web/Pages/Package.cshtml.cs
+++ b/src/BaGetter.Web/Pages/Package.cshtml.cs
@@ -56,6 +56,8 @@ public class PackageModel : PageModel
 
     public HtmlString Readme { get; private set; }
 
+    public HtmlString ParsedReleaseNotes { get; private set; }
+
     public string IconUrl { get; private set; }
     public string LicenseUrl { get; private set; }
     public string PackageDownloadUrl { get; private set; }
@@ -102,6 +104,8 @@ public class PackageModel : PageModel
         {
             Readme = await GetReadmeHtmlStringOrNullAsync(Package.Id, packageVersion, cancellationToken);
         }
+
+        ParsedReleaseNotes = ParseReleaseNotes();
 
         IconUrl = Package.HasEmbeddedIcon
             ? _url.GetPackageIconDownloadUrl(Package.Id, packageVersion)
@@ -206,6 +210,17 @@ public class PackageModel : PageModel
 
         var readmeHtml = Markdown.ToHtml(readme, MarkdownPipeline);
         return new HtmlString(readmeHtml);
+    }
+
+    private HtmlString ParseReleaseNotes()
+    {
+        if (string.IsNullOrWhiteSpace(Package.ReleaseNotes))
+        {
+            return null;
+        }
+
+        var releseNotesHtml = Markdown.ToHtml(Package.ReleaseNotes, MarkdownPipeline);
+        return new HtmlString(releseNotesHtml);
     }
 
     public class DependencyGroupModel

--- a/src/BaGetter.Web/Pages/Package.cshtml.cs
+++ b/src/BaGetter.Web/Pages/Package.cshtml.cs
@@ -216,7 +216,7 @@ public class PackageModel : PageModel
     {
         if (string.IsNullOrWhiteSpace(Package.ReleaseNotes))
         {
-            return null;
+            return HtmlString.Empty;
         }
 
         var releseNotesHtml = Markdown.ToHtml(Package.ReleaseNotes, MarkdownPipeline);


### PR DESCRIPTION
This PR adds the feature to parse the realease notes as Markdown to enable all the features like with the Readme.
Also the dependency `Markdig` was updated to the latest version.

### before

The link is just text.
![before_release_notes](https://github.com/bagetter/BaGetter/assets/6222752/9029a61b-3a9a-4672-962c-056ffcd62aa5)

### after

The link is an actual link.
![after_release_notes](https://github.com/bagetter/BaGetter/assets/6222752/27579705-44cb-4608-9f52-acfd6b452286)
