### PR TITLE
Display tags on package page

### DIFF
--- a/src/BaGetter.Web/Pages/Package.cshtml
+++ b/src/BaGetter.Web/Pages/Package.cshtml
@@ -272,7 +272,12 @@ else
                 <div>
                     <h2>Tags</h2>
 
-                    <p>@string.Join(" ", Model.Package.Tags)</p>
+                    <p>
+                        @foreach(var tag in Model.Package.Tags)
+                        {
+                            <span class="tag">@tag</span>
+                        }
+                    </p>
                 </div>
             }
         </aside>

--- a/src/BaGetter.Web/Pages/Package.cshtml
+++ b/src/BaGetter.Web/Pages/Package.cshtml
@@ -266,6 +266,15 @@ else
                     <p>@string.Join(", ", Model.Package.Authors)</p>
                 </div>
             }
+
+            @if (Model.Package.Tags.Any())
+            {
+                <div>
+                    <h2>Tags</h2>
+
+                    <p>@string.Join(" ", Model.Package.Tags)</p>
+                </div>
+            }
         </aside>
     </div>
 }

--- a/src/BaGetter.Web/wwwroot/css/site.css
+++ b/src/BaGetter.Web/wwwroot/css/site.css
@@ -1,132 +1,141 @@
-﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
+/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
 for details on configuring this project to bundle and minify static web assets. */
 
 /* Layout
 -------------------------------------------------- */
 body {
-    margin: 0;
-    padding: 0;
-    font-family: 'Segoe UI', "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 16px;
+  margin: 0;
+  padding: 0;
+  font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 16px;
 }
 
-h1, h2, h3, h4, h5, h6 {
-    font-family: inherit;
-    font-weight: 100;
-    line-height: 1.1;
-    color: inherit;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: inherit;
+  font-weight: 100;
+  line-height: 1.1;
+  color: inherit;
 }
 
-h1, h2, h3, p {
-    margin-bottom: 24px;
+h1,
+h2,
+h3,
+p {
+  margin-bottom: 24px;
 }
 
 h1 {
-    margin-top: 15px;
+  margin-top: 15px;
 }
 
-h2, h3 {
-    margin-top: 40px;
+h2,
+h3 {
+  margin-top: 40px;
 }
 
 h4 {
-    margin-top: 11px;
-    margin-bottom: 11px;
-    font-size: 20px;
+  margin-top: 11px;
+  margin-bottom: 11px;
+  font-size: 20px;
 }
 
 .img-responsive {
-    display: block;
-    max-width: 100%;
-    height: auto;
+  display: block;
+  max-width: 100%;
+  height: auto;
 }
 
 .ms-Icon-ul {
-    margin-left: 24px;
+  margin-left: 24px;
 }
 
 .ms-Icon-ul li {
-    position: relative;
+  position: relative;
 }
 
 .ms-Icon-ul li i.ms-Icon {
-    position: absolute;
-    left: -24px;
+  position: absolute;
+  left: -24px;
 }
 
 .alert {
-    padding: 8px 8px;
-    border: 1px solid transparent;
-    border-radius: 0;
+  padding: 8px 8px;
+  border: 1px solid transparent;
+  border-radius: 0;
 }
 
 .alert-warning {
-    color: #000;
-    background-color: #fff4ce;
-    border-color: #fff4ce;
+  color: #000;
+  background-color: #fff4ce;
+  border-color: #fff4ce;
 }
 
 /* Navigation
 -------------------------------------------------- */
 #navbar ul {
-    margin-left: -15px;
+  margin-left: -15px;
 }
 
 .navbar-inverse {
-    background-color: #004880;
-    border-color: #002b4d;
+  background-color: #004880;
+  border-color: #002b4d;
 }
 
 .navbar {
-    border-radius: 0;
+  border-radius: 0;
 }
 
 .navbar-inverse .navbar-nav > li > a {
-    font-weight: 100;
-    color: #e3ebf1;
+  font-weight: 100;
+  color: #e3ebf1;
 }
 
 .navbar-nav > li > a {
-    line-height: 22px;
+  line-height: 22px;
 }
 
 .navbar-inverse .navbar-nav a.active {
-    color: #e3ebf1;
+  color: #e3ebf1;
 }
 
 .navbar-inverse .navbar-nav a.active,
 .navbar-inverse .navbar-nav a.active:hover,
 .navbar-inverse .navbar-nav a.active:focus {
-    background-color: transparent;
+  background-color: transparent;
 }
 
 .navbar-inverse .navbar-nav > .active > a:hover {
-    color: #fff;
+  color: #fff;
 }
 
 .navbar-inverse .navbar-nav a.active span {
-    padding: 5px 0;
-    border-bottom: 1px solid #fff;
+  padding: 5px 0;
+  border-bottom: 1px solid #fff;
 }
 
 .nav > li {
-    position: relative;
-    display: block;
+  position: relative;
+  display: block;
 }
 
 .nav > li > a {
-    position: relative;
-    display: block;
-    padding: 10px 15px;
+  position: relative;
+  display: block;
+  padding: 10px 15px;
 }
 
 .search-container {
-    padding-top: 16px;
-    padding-bottom: 16px;
+  padding-top: 16px;
+  padding-bottom: 16px;
 }
 
 .search-container .form-control {
-    border-radius: 0;
+  border-radius: 0;
 }
 
 .search-container button {
@@ -148,182 +157,183 @@ h4 {
 }
 
 .link-button {
-    background-color: transparent;
-    border: none;
-    cursor: pointer;
-    text-decoration: none;
-    display: inline;
-    margin: 0;
-    padding: 0;
-    color: #337ab7;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline;
+  margin: 0;
+  padding: 0;
+  color: #337ab7;
 }
 
 .link-button:hover,
 .link-button:focus {
-    outline: none;
-    text-decoration: underline;
-    color: #23527c;
+  outline: none;
+  text-decoration: underline;
+  color: #23527c;
 }
 
 /* Index page
 -------------------------------------------------- */
 .search-options {
-    margin-bottom: 20px;
+  margin-bottom: 20px;
 }
 
 .search-options span.ms-Checkbox-text {
-    font-weight: bold;
-    font-size: 16px;
+  font-weight: bold;
+  font-size: 16px;
 }
 
 .search-options .form-group {
-    margin-right: 10px;
+  margin-right: 10px;
 }
 
-.search-options select, .search-options #prerelease {
-    margin-left: 10px;
+.search-options select,
+.search-options #prerelease {
+  margin-left: 10px;
 }
 
 .search-dropdown {
-    margin-left: 5px;
-    display: inline-block;
-    width: auto;
-    vertical-align: middle;
+  margin-left: 5px;
+  display: inline-block;
+  width: auto;
+  vertical-align: middle;
 }
 
 .search-result {
-    padding-top: 15px;
-    padding-bottom: 15px;
+  padding-top: 15px;
+  padding-bottom: 15px;
 }
 
 .search-result .package-title {
-    font-size: 24px;
-    font-weight: 300;
-    line-height: .9;
-    margin-right: 5px;
+  font-size: 24px;
+  font-weight: 300;
+  line-height: 0.9;
+  margin-right: 5px;
 }
 
 .search-result .info {
-    padding-left: 0;
-    margin-top: 8px;
-    margin-bottom: 8px;
-    margin-left: -5px;
-    line-height: 20px;
-    color: #666;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  padding-left: 0;
+  margin-top: 8px;
+  margin-bottom: 8px;
+  margin-left: -5px;
+  line-height: 20px;
+  color: #666;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .search-result .info span:not(:first-child) {
-    padding-left: 10px;
+  padding-left: 10px;
 }
 
 .search-result .info li {
-    display: inline;
+  display: inline;
 }
 
 .search-result .info li + li {
-    padding-left: 10px;
-    margin-left: 10px;
-    border-color: #dbdbdb;
-    border-width: 1px;
-    border-left-style: solid;
+  padding-left: 10px;
+  margin-left: 10px;
+  border-color: #dbdbdb;
+  border-width: 1px;
+  border-left-style: solid;
 }
 
 .search-result .ms-Icon {
-    position: relative;
-    top: 2px;
-    margin-right: 2px;
+  position: relative;
+  top: 2px;
+  margin-right: 2px;
 }
 
 .search-result .tags {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Tabbed instructions, used on upload and package page
 -------------------------------------------------- */
 .tabbed-info {
-    font-size: 0.8em;
-    margin-top: 15px;
+  font-size: 0.8em;
+  margin-top: 15px;
 }
 
 .tabbed-info ul {
-    margin-left: 0;
-    margin-bottom: 0;
-    padding-left: 0;
-    list-style: none;
-    border: 0;
-    width: 750px;
+  margin-left: 0;
+  margin-bottom: 0;
+  padding-left: 0;
+  list-style: none;
+  border: 0;
+  width: 750px;
 }
 
 .tabbed-info li {
-    padding: 0;
-    margin-right: 5px;
-    margin-bottom: 0;
-    float: left;
-    position: relative;
-    display: block;
+  padding: 0;
+  margin-right: 5px;
+  margin-bottom: 0;
+  float: left;
+  position: relative;
+  display: block;
 }
 
 .tabbed-info li a {
-    padding: 5px 10px;
-    margin: 0;
-    color: #000;
-    background-color: #eaeaea;
-    border: 0;
-    position: relative;
-    display: block;
-    text-decoration: none;
+  padding: 5px 10px;
+  margin: 0;
+  color: #000;
+  background-color: #eaeaea;
+  border: 0;
+  position: relative;
+  display: block;
+  text-decoration: none;
 }
 
 .tabbed-info li.active a {
-    font-weight: 600;
-    color: #fff;
-    text-decoration: underline;
-    background-color: #002440;
+  font-weight: 600;
+  color: #fff;
+  text-decoration: underline;
+  background-color: #002440;
 }
 
 .tabbed-info .content {
-    display: table;
-    height: 1px;
+  display: table;
+  height: 1px;
 }
 
 .tabbed-info .content .script {
-    display: table-cell;
-    width: 100%;
-    max-width: 1px;
-    padding: 0 10px 8px 10px;
-    font-family: Consolas, Menlo, Monaco, "Courier New", monospace;
-    line-height: 1.5;
-    color: #fff;
-    background-color: #002440;
-    border-color: #002440;
-    border-style: solid;
-    border-width: 1px 0 1px 1px;
+  display: table-cell;
+  width: 100%;
+  max-width: 1px;
+  padding: 0 10px 8px 10px;
+  font-family: Consolas, Menlo, Monaco, "Courier New", monospace;
+  line-height: 1.5;
+  color: #fff;
+  background-color: #002440;
+  border-color: #002440;
+  border-style: solid;
+  border-width: 1px 0 1px 1px;
 }
 
 .tabbed-info .content .script .script-line:before {
-    content: "> ";
+  content: "> ";
 }
 
 .tabbed-info .content .copy-button {
-    display: table-cell;
+  display: table-cell;
 }
 
 .tabbed-info .content .copy-button button {
-    height: 100%;
-    min-height: 42px;
-    vertical-align: baseline;
-    border-radius: 0px;
+  height: 100%;
+  min-height: 42px;
+  vertical-align: baseline;
+  border-radius: 0px;
 }
 
 /* Package page
 -------------------------------------------------- */
 .display-package .package-icon {
-    margin-top: 15px;
+  margin-top: 15px;
 }
 
 @media screen and (max-width: 768px) {
@@ -336,37 +346,37 @@ h4 {
 }
 
 .display-package .package-title {
-    word-break: break-word;
-    overflow-wrap: break-word;
+  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .display-package h1 small {
-    margin-left: 10px;
-    font-size: 45%;
+  margin-left: 10px;
+  font-size: 45%;
 }
 
 .display-package .tabbed-info {
-    margin-bottom: 20px;
+  margin-bottom: 20px;
 }
 
 .display-package .package-description {
-    white-space: pre-wrap;
+  white-space: pre-wrap;
 }
 
 .display-package .package-readme img {
-    max-width: 100%;
+  max-width: 100%;
 }
 
 .display-package .package-release-notes {
-    white-space: pre-wrap;
+  white-space: pre-wrap;
 }
 
 .package-details-info {
-    margin-top: -25px;
+  margin-top: -25px;
 }
 
 .package-details-info .ms-Icon-ul li {
-    margin-bottom: 15px;
+  margin-bottom: 15px;
 }
 
 .package-details-info .icon {
@@ -377,19 +387,27 @@ h4 {
   margin-top: 3px;
 }
 
+.package-details-info .tag {  
+  background-color: #eff9ff;
+  padding: 2px 10px;
+  line-height: 2em;
+  margin: 0 2px;
+}
+
 .display-package .expandable-section h2 button {
-    color: #000;
-    text-decoration: none;
+  color: #000;
+  text-decoration: none;
 }
 
 .display-package .expandable-section h2 .ms-Icon {
-    font-size: 0.6em;
-    position: relative;
-    top: -2px;
-    margin-right: 5px;
+  font-size: 0.6em;
+  position: relative;
+  top: -2px;
+  margin-right: 5px;
 }
 
-.display-package .package-used-by td, .display-package .package-used-by th {
+.display-package .package-used-by td,
+.display-package .package-used-by th {
   padding: 8px 8px 8px 15px;
 }
 
@@ -410,20 +428,20 @@ h4 {
 }
 
 .dependency-groups h4 {
-    line-height: 1.4;
+  line-height: 1.4;
 }
 
 .dependency-groups h4 > span {
-    border-bottom: 1px solid #d8d8d8;
-    margin-bottom: 3px;
+  border-bottom: 1px solid #d8d8d8;
+  margin-bottom: 3px;
 }
 
 .dependency-group li span {
-    color: #666;
+  color: #666;
 }
 
 .display-package .version-list .ms-Icon {
-    position: relative;
-    top: 2px;
-    margin-right: 5px;
+  position: relative;
+  top: 2px;
+  margin-right: 5px;
 }


### PR DESCRIPTION
This PR adds a section `Tags` to the package page similar to the official gallery and the already existing `Authors` section.

### `Tags` section
![after_tag-detail](https://github.com/bagetter/BaGetter/assets/6222752/7bc7790f-740d-4549-b60c-0eead3f093e6)
