### PR TITLE
Fix display of authors on index page

### DIFF
--- a/src/BaGetter.Web/Pages/Index.cshtml
+++ b/src/BaGetter.Web/Pages/Index.cshtml
@@ -119,7 +119,7 @@ else
                        class="package-title">
                         @package.PackageId
                     </a>
-                    <span>by: @string.Join(" ", package.Authors)</span>
+                    <span>by: @string.Join(", ", package.Authors)</span>
                 </div>
                 <ul class="info">
                     <li>


### PR DESCRIPTION
This PR adss a comma between the authors on the index page. This is similar to the `Authors` section on the package page.

### before
![before_author-names](https://github.com/bagetter/BaGetter/assets/6222752/3815639e-ade2-447a-9c4c-d6f481ee19f6)

### after
![after_author-names](https://github.com/bagetter/BaGetter/assets/6222752/fcb941aa-90a4-4556-9519-d0a7ea018f26)
