### PR TITLE
Fix display of tags on index page

### DIFF
--- a/src/BaGetter.Web/wwwroot/css/site.css
+++ b/src/BaGetter.Web/wwwroot/css/site.css
@@ -208,7 +208,7 @@ h4 {
     margin-top: 8px;
     margin-bottom: 8px;
     margin-left: -5px;
-    line-height: 20px;
+    line-height: 22px;
     color: #666;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
This PR fixes the display of tags on the index page by increasing the line height to prevent letters being cut off.

### before
![before_tag-height](https://github.com/bagetter/BaGetter/assets/6222752/973dc754-4b68-4b89-b821-05218e5e7a32)

### after
![after_tag-height](https://github.com/bagetter/BaGetter/assets/6222752/05a94f2a-6caf-40ab-8e4c-7ac1167d4a61)
