### PR TITLE
Parse tags as single elements

### DIFF
--- a/src/BaGetter.Core/Extensions/PackageArchiveReaderExtensions.cs
+++ b/src/BaGetter.Core/Extensions/PackageArchiveReaderExtensions.cs
@@ -111,18 +111,42 @@ public static class PackageArchiveReaderExtensions
 
     private static readonly char[] Separator = { ',', ';', '\t', '\n', '\r' };
 
+    /// <summary>
+    /// Parses the authors into a list of authors.
+    /// </summary>
+    /// <remarks>
+    /// Authors are delimited by comma.<br/>
+    /// See: <see href="https://learn.microsoft.com/en-us/nuget/reference/nuspec#authors"/>
+    /// </remarks>
+    /// <param name="authors">authors to be parsed</param>
+    /// <returns>A list of authors.</returns>
     private static string[] ParseAuthors(string authors)
     {
-        if (string.IsNullOrEmpty(authors)) return Array.Empty<string>();
+        if (string.IsNullOrEmpty(authors))
+        {
+            return Array.Empty<string>();
+        }
 
         return authors.Split(Separator, StringSplitOptions.RemoveEmptyEntries);
     }
 
+    /// <summary>
+    /// Parses the tags into a list of tags.
+    /// </summary>
+    /// <remarks>
+    /// Tags are delimited by space.<br/>
+    /// See: <see href="https://learn.microsoft.com/en-us/nuget/reference/nuspec#tags"/>
+    /// </remarks>
+    /// <param name="tags">tags to be parsed</param>
+    /// <returns>A list of tags.</returns>
     private static string[] ParseTags(string tags)
     {
-        if (string.IsNullOrEmpty(tags)) return Array.Empty<string>();
+        if (string.IsNullOrEmpty(tags))
+        {
+            return Array.Empty<string>();
+        }
 
-        return tags.Split(Separator, StringSplitOptions.RemoveEmptyEntries);
+        return tags.Split(' ', StringSplitOptions.RemoveEmptyEntries);
     }
 
     private static (Uri repositoryUrl, string repositoryType) GetRepositoryMetadata(NuspecReader nuspec)


### PR DESCRIPTION
This PR parses the `tags` from a `nuspec` as single elements.
`tags` are seperated by space (see https://learn.microsoft.com/en-us/nuget/reference/nuspec#tags).

This could be used in the future to filter/search by tag.

### Todo:
- [ ] check if there is a way to "reindex" existing packages