### PR TITLE
Fixed tags parsing for metadata

### DIFF
--- a/src/BaGetter.Core/Extensions/PackageArchiveReaderExtensions.cs
+++ b/src/BaGetter.Core/Extensions/PackageArchiveReaderExtensions.cs
@@ -109,20 +109,27 @@ public static class PackageArchiveReaderExtensions
         return new Uri(uriString);
     }
 
-    private static readonly char[] Separator = { ',', ';', '\t', '\n', '\r' };
+    private static readonly char[] AuthorSeparator = [',', ';', '\t', '\n', '\r'];
 
     private static string[] ParseAuthors(string authors)
     {
-        if (string.IsNullOrEmpty(authors)) return Array.Empty<string>();
+        if (string.IsNullOrEmpty(authors)) return [];
 
-        return authors.Split(Separator, StringSplitOptions.RemoveEmptyEntries);
+        return authors.Split(AuthorSeparator, StringSplitOptions.RemoveEmptyEntries);
     }
+
+    /// <summary>
+    /// MsBuild/NuGet uses semicolons for <c>PackageTags</c> to separate tags and converts them
+    /// into a space separated string for the nuspec file. Any spaces in the original tags will be
+    /// passed through as is, so tags cannot have spaces in them, and space is the only separator.
+    /// </summary>
+    private static readonly char[] TagSeparator = [' '];
 
     private static string[] ParseTags(string tags)
     {
-        if (string.IsNullOrEmpty(tags)) return Array.Empty<string>();
+        if (string.IsNullOrEmpty(tags)) return [];
 
-        return tags.Split(Separator, StringSplitOptions.RemoveEmptyEntries);
+        return tags.Split(TagSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
     }
 
     private static (Uri repositoryUrl, string repositoryType) GetRepositoryMetadata(NuspecReader nuspec)

--- a/src/BaGetter.Core/Upstream/Clients/V3UpstreamClient.cs
+++ b/src/BaGetter.Core/Upstream/Clients/V3UpstreamClient.cs
@@ -18,7 +18,8 @@ public class V3UpstreamClient : IUpstreamClient
 {
     private readonly NuGetClient _client;
     private readonly ILogger<V3UpstreamClient> _logger;
-    private static readonly char[] Separator = { ',', ';', '\t', '\n', '\r' };
+    private static readonly char[] AuthorSeparator = [',', ';', '\t', '\n', '\r'];
+    private static readonly char[] TagSeparator = [' '];
 
     public V3UpstreamClient(NuGetClient client, ILogger<V3UpstreamClient> logger)
     {
@@ -110,7 +111,7 @@ public class V3UpstreamClient : IUpstreamClient
             RepositoryUrl = null,
             RepositoryType = null,
             SemVerLevel = version.IsSemVer2 ? SemVerLevel.SemVer2 : SemVerLevel.Unknown,
-            Tags = metadata.Tags?.ToArray() ?? Array.Empty<string>(),
+            Tags = NormalizeTags(metadata.Tags),
 
             Dependencies = ToDependencies(metadata)
         };
@@ -130,11 +131,17 @@ public class V3UpstreamClient : IUpstreamClient
 
     private static string[] ParseAuthors(string authors)
     {
-        if (string.IsNullOrEmpty(authors)) return Array.Empty<string>();
+        if (string.IsNullOrEmpty(authors)) return [];
 
-        return authors
-            .Split(Separator, StringSplitOptions.RemoveEmptyEntries)
-            .Select(a => a.Trim())
+        return authors.Split(AuthorSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private static string[] NormalizeTags(IEnumerable<string> tags)
+    {
+        if (tags == null) return [];
+
+        return tags
+            .SelectMany(t => t.Split(TagSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             .ToArray();
     }
 

--- a/src/BaGetter.Protocol/Models/PackageMetadata.cs
+++ b/src/BaGetter.Protocol/Models/PackageMetadata.cs
@@ -1,3 +1,4 @@
+using BaGetter.Protocol.Internal;
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
@@ -117,6 +118,7 @@ public class PackageMetadata
     /// The package's tags.
     /// </summary>
     [JsonPropertyName("tags")]
+    [JsonConverter(typeof(StringOrStringArrayJsonConverter))]
     public IReadOnlyList<string> Tags { get; set; }
 
     /// <summary>

--- a/tests/BaGetter.Protocol.Tests/RawPackageMetadataClientTests.cs
+++ b/tests/BaGetter.Protocol.Tests/RawPackageMetadataClientTests.cs
@@ -36,6 +36,33 @@ public class RawPackageMetadataClientTests : IClassFixture<ProtocolFixture>
     }
 
     [Fact]
+    public async Task GetRegistrationIndexLikeGithubPackages()
+    {
+        var result = await _target.GetRegistrationIndexOrNullAsync("my.github.pkg");
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Count);
+        Assert.Collection(result.Pages, page =>
+        {
+            Assert.Equal(2, page.Count);
+            Assert.Collection(page.ItemsOrNull,
+                pkg1 => {
+                    Assert.Equal("2.1.6", pkg1.PackageMetadata.Version);
+                    Assert.Collection(pkg1.PackageMetadata.Tags,
+                        tag1 => Assert.Equal("json bson serializer", tag1)
+                    );
+                },
+                pkg2 => {
+                    Assert.Equal("2.1.5", pkg2.PackageMetadata.Version);
+                    Assert.Collection(pkg2.PackageMetadata.Tags,
+                        tag1 => Assert.Equal("", tag1)
+                    );
+                }
+            );
+        });
+    }
+
+    [Fact]
     public async Task GetRegistrationIndexPagedItems()
     {
         var result = await _target.GetRegistrationIndexOrNullAsync("Paged.Package");

--- a/tests/BaGetter.Protocol.Tests/Support/TestDataHttpMessageHandler.cs
+++ b/tests/BaGetter.Protocol.Tests/Support/TestDataHttpMessageHandler.cs
@@ -21,6 +21,7 @@ public class TestDataHttpMessageHandler : HttpMessageHandler
         //{ TestData.CatalogLeafInvalidDependencyVersionRangeUrl, () => TestData.CatalogLeafInvalidDependencyVersionRange },
 
         { TestData.RegistrationIndexInlinedItemsUrl, () => TestData.RegistrationIndexInlinedItems },
+        { TestData.RegistrationIndexLikeGithubPackagesUrl, () => TestData.RegistrationIndexLikeGithubPackages },
         { TestData.RegistrationIndexPagedItemsUrl, () => TestData.RegistrationIndexPagedItems },
         { TestData.RegistrationLeafUnlistedUrl, () => TestData.RegistrationLeafUnlisted },
         { TestData.RegistrationLeafListedUrl, () => TestData.RegistrationLeafListed },

--- a/tests/BaGetter.Protocol.Tests/TestData.Designer.cs
+++ b/tests/BaGetter.Protocol.Tests/TestData.Designer.cs
@@ -19,7 +19,7 @@ namespace BaGetter.Protocol.Tests {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class TestData {
@@ -87,7 +87,9 @@ namespace BaGetter.Protocol.Tests {
         ///      &quot;commitId&quot;: &quot;c088ef83-7dd6-4d24-86e8-85e3089d2c3b&quot;,
         ///      &quot;commitTimeStamp&quot;: &quot;2010-01-05T00:00:00.000Z&quot;,
         ///      &quot;count&quot;: 2
-        ///    } [rest of string was truncated]&quot;;.
+        ///    },
+        ///    {
+        ///      &quot;@i [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string CatalogIndex {
             get {
@@ -135,7 +137,7 @@ namespace BaGetter.Protocol.Tests {
         ///      &quot;@id&quot;: &quot;https://test.example/v3/catalog/2010.01.05.00.00.00/test.package.1.0.0.json&quot;,
         ///      &quot;@type&quot;: &quot;nuget:PackageDetails&quot;,
         ///      &quot;commitId&quot;: &quot;c088ef83-7dd6-4d24-86e8-85e3089d2c3b&quot;,
-        ///      &quot;commitTimeStamp&quot;: &quot;2010-01- [rest of string was truncated]&quot;;.
+        ///      &quot;commitTimeStamp&quot;: &quot;2010-01-05T00:00:00. [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string CatalogPage {
             get {
@@ -194,7 +196,8 @@ namespace BaGetter.Protocol.Tests {
         ///      &quot;version&quot;: &quot;3.0.0&quot;,
         ///      &quot;description&quot;: &quot;Package description&quot;,
         ///      &quot;summary&quot;: &quot;Package summary&quot;,
-        ///      &quot;title&quot;: &quot;Test.Pack [rest of string was truncated]&quot;;.
+        ///      &quot;title&quot;: &quot;Test.Package&quot;,
+        ///      &quot;ic [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string DefaultSearch {
             get {
@@ -258,7 +261,7 @@ namespace BaGetter.Protocol.Tests {
         ///  &quot;version&quot;: &quot;1.0.0&quot;,
         ///  &quot;@context&quot;: {
         ///    &quot;@vocab&quot;: &quot;http://schema.nuget.org/schema#&quot;,
-        ///    &quot;catalog&quot;: &quot;http://schema.n [rest of string was truncated]&quot;;.
+        ///    &quot;catalog&quot;: &quot;http://schema.nuget.org/catal [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string PackageDeleteCatalogLeaf {
             get {
@@ -290,7 +293,7 @@ namespace BaGetter.Protocol.Tests {
         ///  &quot;iconUrl&quot;: &quot;http://test.example/icon.png&quot;,
         ///  &quot;id&quot;: &quot;Test.Package&quot;,
         ///  &quot;isPrerelease&quot;: false,
-        ///  &quot;lastEdited&quot;: &quot;20 [rest of string was truncated]&quot;;.
+        ///  &quot;lastEdited&quot;: &quot;2010-01-05T00:00 [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string PackageDetailsCatalogLeaf {
             get {
@@ -331,7 +334,8 @@ namespace BaGetter.Protocol.Tests {
         ///    {
         ///      &quot;@id&quot;: &quot;https://test.example/v3/metadata/test.package/index.json#page/1.0.0/1.0.0&quot;,
         ///      &quot;@type&quot;: &quot;catalog:CatalogPage&quot;,
-        ///      &quot;commitId&quot;: &quot;c088ef83-7dd6-4d24-86e8-85e3 [rest of string was truncated]&quot;;.
+        ///      &quot;commitId&quot;: &quot;c088ef83-7dd6-4d24-86e8-85e3089d2c3b&quot;,
+        ///    [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string RegistrationIndexInlinedItems {
             get {
@@ -345,6 +349,36 @@ namespace BaGetter.Protocol.Tests {
         internal static string RegistrationIndexInlinedItemsUrl {
             get {
                 return ResourceManager.GetString("RegistrationIndexInlinedItemsUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///    &quot;count&quot;: 1,
+        ///    &quot;items&quot;: [
+        ///        {
+        ///            &quot;@id&quot;: &quot;https://nuget.pkg.github.com/metadata/my.github.pkg/index.json&quot;,
+        ///            &quot;lower&quot;: &quot;2.1.5&quot;,
+        ///            &quot;upper&quot;: &quot;2.1.6&quot;,
+        ///            &quot;count&quot;: 2,
+        ///            &quot;items&quot;: [
+        ///                {
+        ///                    &quot;@id&quot;: &quot;https://nuget.pkg.github.com/metadata/my.github.pkg/2.1.6.json&quot;,
+        ///                    &quot;packageContent&quot;: &quot;https://nuget.pkg.github.com/metadata/download/my.github.pkg/2.1.6/my.github.pkg.2.1.6.nupkg&quot;,
+        ///                     [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string RegistrationIndexLikeGithubPackages {
+            get {
+                return ResourceManager.GetString("RegistrationIndexLikeGithubPackages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to https://test.example/v3/metadata/my.github.pkg/index.json.
+        /// </summary>
+        internal static string RegistrationIndexLikeGithubPackagesUrl {
+            get {
+                return ResourceManager.GetString("RegistrationIndexLikeGithubPackagesUrl", resourceCulture);
             }
         }
         
@@ -364,7 +398,7 @@ namespace BaGetter.Protocol.Tests {
         ///      &quot;@id&quot;: &quot;https://test.example/v3/metadata/paged.package/page/1.0.0/1.0.0.json&quot;,
         ///      &quot;@type&quot;: &quot;catalog:CatalogPage&quot;,
         ///      &quot;commitId&quot;: &quot;c088ef83-7dd6-4d24-86e8-85e3089d2c3b&quot;,
-        ///      &quot;commi [rest of string was truncated]&quot;;.
+        ///      &quot;commitTimeStamp&quot;: &quot;2 [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string RegistrationIndexPagedItems {
             get {
@@ -393,7 +427,8 @@ namespace BaGetter.Protocol.Tests {
         ///  &quot;packageContent&quot;: &quot;https://test.example/v3/content/test.package/1.0.0/test.package.1.0.0.nupkg&quot;,
         ///  &quot;published&quot;: &quot;2010-01-05T00:00:00.000Z&quot;,
         ///  &quot;registration&quot;: &quot;https://test.example/v3/metadata/test.package/index.json&quot;,
-        ///  &quot;@context&quot;:  [rest of string was truncated]&quot;;.
+        ///  &quot;@context&quot;: {
+        ///    &quot;@voc [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string RegistrationLeafListed {
             get {
@@ -422,7 +457,8 @@ namespace BaGetter.Protocol.Tests {
         ///  &quot;packageContent&quot;: &quot;https://test.example/v3/content/paged.package/2.0.0/paged.package.2.0.0.nupkg&quot;,
         ///  &quot;published&quot;: &quot;2010-01-05T00:00:00.000Z&quot;,
         ///  &quot;registration&quot;: &quot;https://test.example/v3/metadata/paged.package/index.json&quot;,
-        ///  &quot;@cont [rest of string was truncated]&quot;;.
+        ///  &quot;@context&quot;: {
+        ///    [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string RegistrationLeafUnlisted {
             get {
@@ -453,7 +489,7 @@ namespace BaGetter.Protocol.Tests {
         ///    {
         ///      &quot;@id&quot;: &quot;https://test.example/v3/metadata/paged.package/2.0.0.json&quot;,
         ///      &quot;@type&quot;: &quot;Package&quot;,
-        ///      &quot;commitId&quot;: &quot;c088ef83-7dd6- [rest of string was truncated]&quot;;.
+        ///      &quot;commitId&quot;: &quot;c088ef83-7dd6-4d24-86e8-85e [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string RegistrationPage {
             get {
@@ -500,7 +536,7 @@ namespace BaGetter.Protocol.Tests {
         ///    },
         ///    {
         ///      &quot;@id&quot;: &quot;https://test.example/v3/search&quot;,
-        ///      &quot;@type&quot;: &quot;Searc [rest of string was truncated]&quot;;.
+        ///      &quot;@type&quot;: &quot;SearchQueryService/3.4.0&quot; [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ServiceIndex {
             get {

--- a/tests/BaGetter.Protocol.Tests/TestData.resx
+++ b/tests/BaGetter.Protocol.Tests/TestData.resx
@@ -723,6 +723,70 @@
   <data name="RegistrationIndexInlinedItemsUrl" xml:space="preserve">
     <value>https://test.example/v3/metadata/test.package/index.json</value>
   </data>
+  <data name="RegistrationIndexLikeGithubPackages" xml:space="preserve">
+    <value>{
+    "count": 1,
+    "items": [
+        {
+            "@id": "https://nuget.pkg.github.com/metadata/my.github.pkg/index.json",
+            "lower": "2.1.5",
+            "upper": "2.1.6",
+            "count": 2,
+            "items": [
+                {
+                    "@id": "https://nuget.pkg.github.com/metadata/my.github.pkg/2.1.6.json",
+                    "packageContent": "https://nuget.pkg.github.com/metadata/download/my.github.pkg/2.1.6/my.github.pkg.2.1.6.nupkg",
+                    "catalogEntry": {
+                        "@id": "https://nuget.pkg.github.com/metadata/my.github.pkg/2.1.6.json",
+                        "authors": "Someone",
+                        "copyright": "",
+                        "dependencyGroups": [
+                        ],
+                        "description": "Nice library",
+                        "iconUrl": "",
+                        "id": "my.github.pkg",
+                        "isPrerelease": false,
+                        "language": "",
+                        "licenseUrl": "https://licenses.nuget.org/MIT",
+                        "packageContent": "https://nuget.pkg.github.com/metadata/download/my.github.pkg/2.1.6/my.github.pkg.2.1.6.nupkg",
+                        "projectUrl": "https://github.com/User/Project",
+                        "requireLicenseAcceptance": false,
+                        "summary": "",
+                        "tags": "json bson serializer",
+                        "version": "2.1.6"
+                    }
+                },
+                {
+                    "@id": "https://nuget.pkg.github.com/metadata/my.github.pkg/2.1.5.json",
+                    "packageContent": "https://nuget.pkg.github.com/metadata/download/my.github.pkg/2.1.5/my.github.pkg.2.1.5.nupkg",
+                    "catalogEntry": {
+                        "@id": "https://nuget.pkg.github.com/metadata/my.github.pkg/2.1.5.json",
+                        "authors": "Someone",
+                        "copyright": "",
+                        "dependencyGroups": [
+                        ],
+                        "description": "Nice library",
+                        "iconUrl": "",
+                        "id": "my.github.pkg",
+                        "isPrerelease": false,
+                        "language": "",
+                        "licenseUrl": "https://licenses.nuget.org/MIT",
+                        "packageContent": "https://nuget.pkg.github.com/metadata/download/my.github.pkg/2.1.5/my.github.pkg.2.1.5.nupkg",
+                        "projectUrl": "https://github.com/User/Project",
+                        "requireLicenseAcceptance": false,
+                        "summary": "",
+                        "tags": "",
+                        "version": "2.1.5"
+                    }
+                }
+            ]
+        }
+    ]
+}</value>
+  </data>
+  <data name="RegistrationIndexLikeGithubPackagesUrl" xml:space="preserve">
+    <value>https://test.example/v3/metadata/my.github.pkg/index.json</value>
+  </data>
   <data name="RegistrationIndexPagedItems" xml:space="preserve">
     <value>{
   "@id": "https://test.example/v3/metadata/paged.package/index.json",

--- a/tests/BaGetter.Tests/Support/StreamExtensions.cs
+++ b/tests/BaGetter.Tests/Support/StreamExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using Newtonsoft.Json;
 
 namespace BaGetter.Tests;
@@ -18,6 +18,6 @@ public static class StreamExtensions
         using var jsonReader = new JsonTextReader(reader);
 
         jsonWriter.WriteToken(jsonReader);
-        return writer.ToString();
+        return writer.ToString().Replace("\r\n", "\n");
     }
 }


### PR DESCRIPTION
Summary of the changes (in less than 80 chars)

 * Fix parsing tags from feeds which had them in a single space-separated string
 * Fix parsing tags from nuspec from `[ "tag1 tag2" ]` to `["tag1", "tag2"]`

Addresses https://github.com/bagetter/BaGetter/issues/89

## Annotations

It felt weird in the unit test to check the deserialized value of the tags to be `[ "json bson serializer" ]`, but I don't think tag normalizing should happen in the `JsonConveter`.
The tags will be properly split up in the `V3UpstreamClient.ToPackage` method.

I had to add `.Replace("\r\n", "\n")` in the unit test json writer otherwise all related tests would fail.
It seems that the strings in the tests are declared with `\n` even though the `.editorconfig` defines `\r\n` as the project line endings.
The github actions will probably be default run linux, but i'm on a windows machine so it apparently wrote the json with crlf.
You could maybe consider checking json for structural equality instead of string-wise like this https://github.com/Splamy/JsonBinMin/blob/main/JsonBinMin.Tests/AssertUtil.cs#L17-L57 or if you find a good library.
