### PR TITLE
Prerelease package overwrites

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -69,18 +69,31 @@ downloaded if you know the package's id and version. You can override this behav
 
 ## Enable package overwrites
 
-Normally, BaGetter will reject a package upload if the id and version are already taken. You can configure BaGetter
-to overwrite the already existing package by setting `AllowPackageOverwrites`:
+Normally, BaGetter will reject a package upload if the id and version are already taken. This is to maintain the [immutability of semantically versioned packages](https://learn.microsoft.com/en-us/azure/devops/artifacts/artifacts-key-concepts?view=azure-devops#immutability).
+
+:::warning
+
+NuGet clients cache packages on multiple levels, so overwriting a package can lead to unexpected behavior.
+A client may have a cached version of the package that is different from the one on the server.
+Make sure, everyone involved is aware of the implications of overwriting packages.
+
+:::
+
+You can configure BaGetter to overwrite the already existing package by setting `AllowPackageOverwrites`:
 
 ```json
 {
     ...
 
-    "AllowPackageOverwrites": true,
+    "AllowPackageOverwrites": "true",
 
     ...
 }
 ```
+
+To allow pre-release versions to be overwritten but not proper releases, set `AllowPackageOverwrites` to `PrereleaseOnly`.
+
+Pushing a package with a pre-release version like "3.1.0-SNAPSHOT" will overwrite the existing "3.1.0-SNAPSHOT" package, but pushing a "3.1.0" package will fail if a "3.1.0" package already exists.
 
 ## Private feeds
 

--- a/src/BaGetter.Core/Configuration/BaGetterOptions.cs
+++ b/src/BaGetter.Core/Configuration/BaGetterOptions.cs
@@ -30,7 +30,7 @@ public class BaGetterOptions
     /// If enabled, pushing a package that already exists will replace the
     /// existing package.
     /// </summary>
-    public bool AllowPackageOverwrites { get; set; } = false;
+    public PackageOverwriteAllowed AllowPackageOverwrites { get; set; } = PackageOverwriteAllowed.False;
 
     /// <summary>
     /// If true, disables package pushing, deleting, and re-listing.

--- a/src/BaGetter.Core/Configuration/PackageOverwriteAllowed.cs
+++ b/src/BaGetter.Core/Configuration/PackageOverwriteAllowed.cs
@@ -1,0 +1,22 @@
+namespace BaGetter.Core;
+
+/// <summary>
+/// How BaGetter should react to a package being pushed that already exists.
+/// </summary>
+public enum PackageOverwriteAllowed
+{
+    /// <summary>
+    /// Disallows all packages from being overwritten. This is the recommended setting and default behaviour for nuget.org and most other NuGet servers.
+    /// </summary>
+    False,
+
+    /// <summary>
+    /// Allows only prerelease packages to be overwritten.
+    /// </summary>
+    PrereleaseOnly,
+
+    /// <summary>
+    /// Allows all packages to be overwritten. Not recommended.
+    /// </summary>
+    True
+}

--- a/src/BaGetter.Core/Entities/Package.cs
+++ b/src/BaGetter.Core/Entities/Package.cs
@@ -18,9 +18,7 @@ public class Package
             // Favor the original version string as it contains more information.
             // Packages uploaded with older versions of BaGetter may not have the original version string.
             return NuGetVersion.Parse(
-                OriginalVersionString != null
-                    ? OriginalVersionString
-                    : NormalizedVersionString);
+                OriginalVersionString ?? NormalizedVersionString);
         }
 
         set

--- a/src/BaGetter.Core/Indexing/PackageIndexingService.cs
+++ b/src/BaGetter.Core/Indexing/PackageIndexingService.cs
@@ -80,7 +80,8 @@ public class PackageIndexingService : IPackageIndexingService
         // The package is well-formed. Ensure this is a new package.
         if (await _packages.ExistsAsync(package.Id, package.Version, cancellationToken))
         {
-            if (!_options.Value.AllowPackageOverwrites)
+            if (_options.Value.AllowPackageOverwrites == PackageOverwriteAllowed.False ||
+                (_options.Value.AllowPackageOverwrites == PackageOverwriteAllowed.PrereleaseOnly && !package.IsPrerelease))
             {
                 return PackageIndexingResult.PackageAlreadyExists;
             }

--- a/tests/BaGetter.Core.Tests/Services/PackageIndexingServiceTests.cs
+++ b/tests/BaGetter.Core.Tests/Services/PackageIndexingServiceTests.cs
@@ -1,7 +1,11 @@
+using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
+using NuGet.Packaging;
+using NuGet.Versioning;
 using Xunit;
 
 namespace BaGetter.Core.Tests.Services;
@@ -13,45 +17,199 @@ public class PackageIndexingServiceTests
     private readonly Mock<ISearchIndexer> _search;
     private readonly Mock<SystemTime> _time;
     private readonly PackageIndexingService _target;
+    private readonly BaGetterOptions _mockOptions;
 
     public PackageIndexingServiceTests()
     {
-        _packages = new Mock<IPackageDatabase>();
-        _storage = new Mock<IPackageStorageService>();
-        _search = new Mock<ISearchIndexer>();
-        _time = new Mock<SystemTime>();
+        _packages = new Mock<IPackageDatabase>(MockBehavior.Strict);
+        _storage = new Mock<IPackageStorageService>(MockBehavior.Strict);
+        _search = new Mock<ISearchIndexer>(MockBehavior.Strict);
+        _time = new Mock<SystemTime>(MockBehavior.Loose);
+        _mockOptions = new();
+        var options = new Mock<IOptionsSnapshot<BaGetterOptions>>(MockBehavior.Strict);
+        options.Setup(o => o.Value).Returns(_mockOptions);
 
         _target = new PackageIndexingService(
             _packages.Object,
             _storage.Object,
             _search.Object,
             _time.Object,
-            Mock.Of<IOptionsSnapshot<BaGetterOptions>>(),
+            options.Object,
             Mock.Of<ILogger<PackageIndexingService>>());
     }
 
     // TODO: Add malformed package tests
 
     [Fact]
-    public async Task WhenPackageAlreadyExists_ReturnsPackageAlreadyExists()
+    public async Task IndexAsync_WhenPackageAlreadyExists_AndOverwriteForbidden_ReturnsPackageAlreadyExists()
     {
-        await Task.Yield();
+        // Arrange
+        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.False;
+
+        var builder = new PackageBuilder
+        {
+            Id = "bagetter-test",
+            Version = NuGetVersion.Parse("1.0.0"),
+            Description = "Test Description",
+        };
+        builder.Authors.Add("Test Author");
+        var assemblyFile = GetType().Assembly.Location;
+        builder.Files.Add(new PhysicalPackageFile
+        {
+            SourcePath = assemblyFile,
+            TargetPath = "lib/Test.dll"
+        });
+        var stream = new MemoryStream();
+        builder.Save(stream);
+        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
+
+        // Act
+        var result = await _target.IndexAsync(stream, default);
+
+        // Assert
+        Assert.Equal(PackageIndexingResult.PackageAlreadyExists, result);
+    }
+
+    [Fact]
+    public async Task IndexAsync_WhenPackageAlreadyExists_AndOverwriteAllowed_IndexesPackage()
+    {
+        // Arrange
+        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.True;
+
+        var builder = new PackageBuilder
+        {
+            Id = "bagetter-test",
+            Version = NuGetVersion.Parse("1.0.0"),
+            Description = "Test Description",
+        };
+        builder.Authors.Add("Test Author");
+        var assemblyFile = GetType().Assembly.Location;
+        builder.Files.Add(new PhysicalPackageFile
+        {
+            SourcePath = assemblyFile,
+            TargetPath = "lib/Test.dll"
+        });
+        var stream = new MemoryStream();
+        builder.Save(stream);
+        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
+        _packages.Setup(p => p.HardDeletePackageAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
+        _packages.Setup(p => p.AddAsync(It.Is<Package>(p1 => p1.Id == builder.Id && p1.Version.ToString() == builder.Version.ToString()), default)).ReturnsAsync(PackageAddResult.Success);
+
+        _storage.Setup(s => s.DeleteAsync(builder.Id, builder.Version, default)).Returns(Task.CompletedTask);
+        _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
+
+        _search.Setup(s => s.IndexAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), default)).Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _target.IndexAsync(stream, default);
+
+        // Assert
+        Assert.Equal(PackageIndexingResult.Success, result);
+    }
+
+    [Fact]
+    public async Task IndexAsync_WhenPrereleasePackageAlreadyExists_AndOverwritePrereleaseAllowed_IndexesPackage()
+    {
+        // Arrange
+        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.PrereleaseOnly;
+
+        var builder = new PackageBuilder
+        {
+            Id = "bagetter-test",
+            Version = NuGetVersion.Parse("1.0.0-beta"),
+            Description = "Test Description",
+        };
+        builder.Authors.Add("Test Author");
+        var assemblyFile = GetType().Assembly.Location;
+        builder.Files.Add(new PhysicalPackageFile
+        {
+            SourcePath = assemblyFile,
+            TargetPath = "lib/Test.dll"
+        });
+        var stream = new MemoryStream();
+        builder.Save(stream);
+        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
+        _packages.Setup(p => p.HardDeletePackageAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
+        _packages.Setup(p => p.AddAsync(It.Is<Package>(p1 => p1.Id == builder.Id && p1.Version.ToString() == builder.Version.ToString()), default)).ReturnsAsync(PackageAddResult.Success);
+
+        _storage.Setup(s => s.DeleteAsync(builder.Id, builder.Version, default)).Returns(Task.CompletedTask);
+        _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
+
+        _search.Setup(s => s.IndexAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), default)).Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _target.IndexAsync(stream, default);
+
+        // Assert
+        Assert.Equal(PackageIndexingResult.Success, result);
+    }
+
+    [Fact]
+    public async Task IndexAsync_WhenPrereleasePackageAlreadyExists_AndOverwriteForbidden_ReturnsPackageAlreadyExists()
+    {
+        // Arrange
+        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.False;
+
+        var builder = new PackageBuilder
+        {
+            Id = "bagetter-test",
+            Version = NuGetVersion.Parse("1.0.0-beta"),
+            Description = "Test Description",
+        };
+        builder.Authors.Add("Test Author");
+        var assemblyFile = GetType().Assembly.Location;
+        builder.Files.Add(new PhysicalPackageFile
+        {
+            SourcePath = assemblyFile,
+            TargetPath = "lib/Test.dll"
+        });
+        var stream = new MemoryStream();
+        builder.Save(stream);
+        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
+
+        // Act
+        var result = await _target.IndexAsync(stream, default);
+
+        // Assert
+        Assert.Equal(PackageIndexingResult.PackageAlreadyExists, result);
+    }
+
+    [Fact]
+    public async Task IndexAsync_WithValidPackage_ReturnsSuccess()
+    {
+        // Arrange
+        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.False;
+        var builder = new PackageBuilder
+        {
+            Id = "bagetter-test",
+            Version = NuGetVersion.Parse("1.0.0"),
+            Description = "Test Description",
+        };
+        builder.Authors.Add("Test Author");
+        var assemblyFile = GetType().Assembly.Location;
+        builder.Files.Add(new PhysicalPackageFile
+        {
+            SourcePath = assemblyFile,
+            TargetPath = "lib/Test.dll"
+        });
+        var stream = new MemoryStream();
+        builder.Save(stream);
+        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(false);
+        _packages.Setup(p => p.AddAsync(It.Is<Package>(p1 => p1.Id == builder.Id && p1.Version.ToString() == builder.Version.ToString()), default)).ReturnsAsync(PackageAddResult.Success);
+
+        _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
+
+        _search.Setup(s => s.IndexAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), default)).Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _target.IndexAsync(stream, default);
+
+        // Assert
+        Assert.Equal(PackageIndexingResult.Success, result);
     }
 
     [Fact]
     public async Task WhenDatabaseAddFailsBecausePackageAlreadyExists_ReturnsPackageAlreadyExists()
-    {
-        await Task.Yield();
-    }
-
-    [Fact]
-    public async Task IndexesPackage()
-    {
-        await Task.Yield();
-    }
-
-    [Fact]
-    public async Task WhenPackageHasNoReadme_SavesNullReadmeStream()
     {
         await Task.Yield();
     }


### PR DESCRIPTION
This adds a mode `PrereleaseOnly` to the `AllowPackageOverwrites` configuration setting. 

It's now an enum, but I kept the others as "True" and "False" so booleans can still be used in the appsettings files, keeping them backwards compatible.

Closes #69