### PR TITLE
Increase max package size to ~8GB

### DIFF
--- a/docs/docs/Index.md
+++ b/docs/docs/Index.md
@@ -16,6 +16,8 @@ BaGetter (pronounced "ba getter") is a lightweight NuGet and symbol server. It i
   <img width="100%" src="https://user-images.githubusercontent.com/737941/50140219-d8409700-0258-11e9-94c9-dad24d2b48bb.png"/>
 </CenterImg>
 
+BaGetter supports Filesystem, GCP and AWS S3 buckets for package storage, and MySQL, Sqlite, SqlServer and PostgreSQL as database. The current per-package size limit is ~8GB. It can be hosted on IIS, and is also available in a linux docker container.
+
 ## Run BaGetter
 
 You can run BaGetter on your preferred platform:

--- a/docs/docs/Index.md
+++ b/docs/docs/Index.md
@@ -16,7 +16,7 @@ BaGetter (pronounced "ba getter") is a lightweight NuGet and symbol server. It i
   <img width="100%" src="https://user-images.githubusercontent.com/737941/50140219-d8409700-0258-11e9-94c9-dad24d2b48bb.png"/>
 </CenterImg>
 
-BaGetter supports Filesystem, GCP and AWS S3 buckets for package storage, and MySQL, Sqlite, SqlServer and PostgreSQL as database. The current per-package size limit is ~8GB. It can be hosted on IIS, and is also available in a linux docker container.
+BaGetter supports Filesystem, GCP and AWS S3 buckets for package storage, and MySQL, Sqlite, SqlServer and PostgreSQL as database. The current per-package size limit is ~8GB. It can be hosted on IIS, and is also available in a linux [docker image](https://hub.docker.com/r/bagetter/bagetter).
 
 ## Run BaGetter
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -170,6 +170,21 @@ If not specified, the `MaxRequestBodySize` in BaGetter defaults to 250MB (262144
 }
 ```
 
+## Maximum package size
+
+The max package size default to 8GiB and can be configured using the `MaxPackageSizeGiB` setting. The NuGet gallery currently has a 250MB limit, which is enough for most packages.
+This can be useful if you are hosting a private feed and need to host large packages that include chocolatey installers, machine learning models, etc.
+
+```json
+{
+    ...
+
+    "MaxPackageSizeGiB": 8,
+
+    ...
+}
+```
+
 ## Load secrets from files
 
 Mostly useful when running containerised (e.g. using Docker, Podman, Kubernetes, etc), the application will look for files named in the same pattern as environment variables under `/run/secrets`.

--- a/src/BaGetter.Core/Configuration/BaGetterOptions.cs
+++ b/src/BaGetter.Core/Configuration/BaGetterOptions.cs
@@ -43,6 +43,12 @@ public class BaGetterOptions
     /// </summary>
     public string Urls { get; set; }
 
+    /// <summary>
+    /// The maximum package size in GB.
+    /// Attempted uploads of packages larger than this will be rejected with an internal server error carrying one <see cref="System.IO.InvalidDataException"/>.
+    /// </summary>
+    public uint MaxPackageSizeGiB { get; set; } = 8;
+
     public DatabaseOptions Database { get; set; }
 
     public StorageOptions Storage { get; set; }

--- a/src/BaGetter/ConfigureBaGetterOptions.cs
+++ b/src/BaGetter/ConfigureBaGetterOptions.cs
@@ -64,6 +64,7 @@ public class ConfigureBaGetterOptions
 
     public void Configure(FormOptions options)
     {
+        // Allow packages up to ~8GB in size
         options.MultipartBodyLengthLimit = int.MaxValue * (long)4;
     }
 

--- a/src/BaGetter/ConfigureBaGetterOptions.cs
+++ b/src/BaGetter/ConfigureBaGetterOptions.cs
@@ -64,7 +64,7 @@ public class ConfigureBaGetterOptions
 
     public void Configure(FormOptions options)
     {
-        options.MultipartBodyLengthLimit = int.MaxValue;
+        options.MultipartBodyLengthLimit = int.MaxValue * (long)4;
     }
 
     public void Configure(ForwardedHeadersOptions options)

--- a/src/BaGetter/ConfigureBaGetterServer.cs
+++ b/src/BaGetter/ConfigureBaGetterServer.cs
@@ -1,0 +1,54 @@
+using BaGetter.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Options;
+
+namespace BaGetter;
+
+public class ConfigureBaGetterServer
+    : IConfigureOptions<CorsOptions>
+    , IConfigureOptions<FormOptions>
+    , IConfigureOptions<ForwardedHeadersOptions>
+    , IConfigureOptions<IISServerOptions>
+{
+    public const string CorsPolicy = "AllowAll";
+    private readonly BaGetterOptions _baGetterOptions;
+
+    public ConfigureBaGetterServer(IOptions<BaGetterOptions> baGetterOptions)
+    {
+        _baGetterOptions = baGetterOptions.Value;
+    }
+
+
+    public void Configure(CorsOptions options)
+    {
+        // TODO: Consider disabling this on production builds.
+        options.AddPolicy(
+            CorsPolicy,
+            builder => builder.AllowAnyOrigin()
+                .AllowAnyMethod()
+                .AllowAnyHeader());
+    }
+
+    public void Configure(FormOptions options)
+    {
+        // Allow packages up to ~8GiB in size
+        options.MultipartBodyLengthLimit = (long) _baGetterOptions.MaxPackageSizeGiB * int.MaxValue / 2;
+    }
+
+    public void Configure(ForwardedHeadersOptions options)
+    {
+        options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+
+        // Do not restrict to local network/proxy
+        options.KnownNetworks.Clear();
+        options.KnownProxies.Clear();
+    }
+
+    public void Configure(IISServerOptions options)
+    {
+        options.MaxRequestBodySize = 262144000;
+    }
+}

--- a/src/BaGetter/ConfigureBaGetterServer.cs
+++ b/src/BaGetter/ConfigureBaGetterServer.cs
@@ -49,6 +49,6 @@ public class ConfigureBaGetterServer
 
     public void Configure(IISServerOptions options)
     {
-        options.MaxRequestBodySize = 262144000;
+        options.MaxRequestBodySize = (long)_baGetterOptions.MaxPackageSizeGiB * int.MaxValue / 2;
     }
 }

--- a/src/BaGetter/Startup.cs
+++ b/src/BaGetter/Startup.cs
@@ -24,7 +24,8 @@ public class Startup
 
     public void ConfigureServices(IServiceCollection services)
     {
-        services.ConfigureOptions<ConfigureBaGetterOptions>();
+        services.ConfigureOptions<ValidateBaGetterOptions>();
+        services.ConfigureOptions<ConfigureBaGetterServer>();
 
         services.AddBaGetterOptions<IISServerOptions>(nameof(IISServerOptions));
         services.AddBaGetterWebApplication(ConfigureBaGetterApplication);
@@ -80,7 +81,7 @@ public class Startup
         app.UseStaticFiles();
         app.UseRouting();
 
-        app.UseCors(ConfigureBaGetterOptions.CorsPolicy);
+        app.UseCors(ConfigureBaGetterServer.CorsPolicy);
         app.UseOperationCancelledMiddleware();
 
         app.UseEndpoints(endpoints =>

--- a/src/BaGetter/ValidateBaGetterOptions.cs
+++ b/src/BaGetter/ValidateBaGetterOptions.cs
@@ -14,15 +14,9 @@ namespace BaGetter;
 /// BaGetter's options configuration, specific to the default BaGetter application.
 /// Don't use this if you are embedding BaGetter into your own custom ASP.NET Core application.
 /// </summary>
-public class ConfigureBaGetterOptions
-    : IConfigureOptions<CorsOptions>
-    , IConfigureOptions<FormOptions>
-    , IConfigureOptions<ForwardedHeadersOptions>
-    , IConfigureOptions<IISServerOptions>
-    , IValidateOptions<BaGetterOptions>
+public class ValidateBaGetterOptions
+    : IValidateOptions<BaGetterOptions>
 {
-    public const string CorsPolicy = "AllowAll";
-
     private static readonly HashSet<string> ValidDatabaseTypes
         = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -51,36 +45,6 @@ public class ConfigureBaGetterOptions
             "Database",
             "Null",
         };
-
-    public void Configure(CorsOptions options)
-    {
-        // TODO: Consider disabling this on production builds.
-        options.AddPolicy(
-            CorsPolicy,
-            builder => builder.AllowAnyOrigin()
-                .AllowAnyMethod()
-                .AllowAnyHeader());
-    }
-
-    public void Configure(FormOptions options)
-    {
-        // Allow packages up to ~8GB in size
-        options.MultipartBodyLengthLimit = int.MaxValue * (long)4;
-    }
-
-    public void Configure(ForwardedHeadersOptions options)
-    {
-        options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
-
-        // Do not restrict to local network/proxy
-        options.KnownNetworks.Clear();
-        options.KnownProxies.Clear();
-    }
-
-    public void Configure(IISServerOptions options)
-    {
-        options.MaxRequestBodySize = 262144000;
-    }
 
     public ValidateOptionsResult Validate(string name, BaGetterOptions options)
     {

--- a/src/BaGetter/appsettings.json
+++ b/src/BaGetter/appsettings.json
@@ -2,6 +2,7 @@
   "ApiKey": "",
   "PackageDeletionBehavior": "Unlist",
   "AllowPackageOverwrites": false,
+  "MaxPackageSizeGiB": 8,
 
   "Database": {
     "Type": "Sqlite",


### PR DESCRIPTION
Is there a limit we should stay in? The whole thing might be in memory while uploaded, for example in the AWS storage service, temporarily hiking RAM usage to up to ~8GB (or whatever limit we set). Should we put an info box somewhere that tells people that uploaded packages will be temporarily in memory, thus possibly spiking RAM?

Closes #101