### PR TITLE
add basic healthcheck feature #105

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -170,6 +170,25 @@ If not specified, the `MaxRequestBodySize` in BaGetter defaults to 250MB (262144
 }
 ```
 
+## Health Endpoint
+
+When running within a containerized environment like Kubernetes, a basic health endpoint is exposed at `/health` that returns 200 OK and the text "Healthy" when running.
+
+This path is configurable if needed:
+
+
+```json
+{
+    ...
+
+    "HealthCheck": {
+        "Path": "/healthz"
+    },
+
+    ...
+}
+```
+
 ## Load secrets from files
 
 Mostly useful when running containerised (e.g. using Docker, Podman, Kubernetes, etc), the application will look for files named in the same pattern as environment variables under `/run/secrets`.
@@ -179,6 +198,7 @@ Mostly useful when running containerised (e.g. using Docker, Podman, Kubernetes,
 ```
 
 This allows for sensitive values to be provided individually to the application, typically by bind-mounting files.
+
 
 ### Docker Compose example
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -176,7 +176,6 @@ When running within a containerized environment like Kubernetes, a basic health 
 
 This path is configurable if needed:
 
-
 ```json
 {
     ...
@@ -198,7 +197,6 @@ Mostly useful when running containerised (e.g. using Docker, Podman, Kubernetes,
 ```
 
 This allows for sensitive values to be provided individually to the application, typically by bind-mounting files.
-
 
 ### Docker Compose example
 

--- a/src/BaGetter.Core/Configuration/BaGetterOptions.cs
+++ b/src/BaGetter.Core/Configuration/BaGetterOptions.cs
@@ -50,4 +50,6 @@ public class BaGetterOptions
     public SearchOptions Search { get; set; }
 
     public MirrorOptions Mirror { get; set; }
+
+    public HealthCheckOptions HealthCheck { get; set; }
 }

--- a/src/BaGetter.Core/Configuration/HealthCheckOptions.cs
+++ b/src/BaGetter.Core/Configuration/HealthCheckOptions.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace BaGetter.Core;
+
+public class HealthCheckOptions : IValidatableObject
+{
+    [Required]
+    public string Path { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (! Path.StartsWith('/'))
+        {
+            yield return new ValidationResult(
+                $"The {nameof(Path)} needs to start with a /",
+                new[] { nameof(Path) });
+        }
+    }
+}

--- a/src/BaGetter.Core/Validation/ValidateStartupOptions.cs
+++ b/src/BaGetter.Core/Validation/ValidateStartupOptions.cs
@@ -13,6 +13,7 @@ public class ValidateStartupOptions
     private readonly IOptions<DatabaseOptions> _database;
     private readonly IOptions<StorageOptions> _storage;
     private readonly IOptions<MirrorOptions> _mirror;
+    private readonly IOptions<HealthCheckOptions> _healthCheck;
     private readonly ILogger<ValidateStartupOptions> _logger;
 
     public ValidateStartupOptions(
@@ -20,12 +21,14 @@ public class ValidateStartupOptions
         IOptions<DatabaseOptions> database,
         IOptions<StorageOptions> storage,
         IOptions<MirrorOptions> mirror,
+        IOptions<HealthCheckOptions> healthCheck,
         ILogger<ValidateStartupOptions> logger)
     {
         _root = root ?? throw new ArgumentNullException(nameof(root));
         _database = database ?? throw new ArgumentNullException(nameof(database));
         _storage = storage ?? throw new ArgumentNullException(nameof(storage));
         _mirror = mirror ?? throw new ArgumentNullException(nameof(mirror));
+        _healthCheck = healthCheck ?? throw new ArgumentNullException(nameof(healthCheck));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -39,6 +42,7 @@ public class ValidateStartupOptions
             _ = _database.Value;
             _ = _storage.Value;
             _ = _mirror.Value;
+            _ = _healthCheck.Value;
 
             return true;
         }

--- a/src/BaGetter/Startup.cs
+++ b/src/BaGetter/Startup.cs
@@ -40,6 +40,8 @@ public class Startup
 
         services.AddSingleton<IConfigureOptions<MvcRazorRuntimeCompilationOptions>, ConfigureRazorRuntimeCompilation>();
 
+        services.AddHealthChecks();
+
         services.AddCors();
     }
 
@@ -89,5 +91,7 @@ public class Startup
 
             baget.MapEndpoints(endpoints);
         });
+
+        app.UseHealthChecks("/healthz");
     }
 }

--- a/src/BaGetter/Startup.cs
+++ b/src/BaGetter/Startup.cs
@@ -92,6 +92,6 @@ public class Startup
             baget.MapEndpoints(endpoints);
         });
 
-        app.UseHealthChecks("/healthz");
+        app.UseHealthChecks(options.HealthCheck.Path);
     }
 }

--- a/src/BaGetter/appsettings.json
+++ b/src/BaGetter/appsettings.json
@@ -48,5 +48,9 @@
         "Default": "Warning"
       }
     }
+  },
+
+  "HealthCheck": {
+    "Path" : "/health"
   }
 }


### PR DESCRIPTION
Summary of the changes (in less than 80 chars)

 * Added the most basic healthz endpoint

Addresses https://github.com/bagetter/BaGet/issues/105
I tried adding the database provider health checks at the same time, however the way the registration of those via the IProvider interface made it a lot more difficult than I have time for right now.
