### PR TITLE
Display version of BaGetter in a footer on Website

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           global-json-file: global.json
       - name: Publish
         run: |
-          dotnet publish src/BaGetter --configuration Release --output artifacts
+          dotnet publish src/BaGetter --configuration Release --output artifacts --property:Version=${{ needs.version.outputs.RELEASE_VERSION }}
           echo ${{ github.sha }} > artifacts/ReleaseSha.txt
           7z a -tzip bagetter-${{ needs.version.outputs.RELEASE_VERSION }}.zip ./artifacts/*
       - name: Generate changelog with git-cliff
@@ -79,7 +79,7 @@ jobs:
           export PackageVersion=${{ needs.version.outputs.RELEASE_VERSION }}
           export PackageSource=${PackageSource:="https://api.nuget.org/v3/index.json"}
           echo "PackageSource=${PackageSource}" >> $GITHUB_ENV
-          dotnet pack --configuration Release --output artifacts
+          dotnet pack --configuration Release --output artifacts --property:Version=${{ needs.version.outputs.RELEASE_VERSION }}
       - name: Push
         run: dotnet nuget push "*" -s ${PackageSource} -k ${{secrets.NUGET_API_KEY}}
         working-directory: artifacts

--- a/BaGetter.sln
+++ b/BaGetter.sln
@@ -27,6 +27,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.targets = src\Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
 		Dockerfile = Dockerfile
 		nuget.config = nuget.config

--- a/docs/docs/Index.md
+++ b/docs/docs/Index.md
@@ -16,6 +16,8 @@ BaGetter (pronounced "ba getter") is a lightweight NuGet and symbol server. It i
   <img width="100%" src="https://user-images.githubusercontent.com/737941/50140219-d8409700-0258-11e9-94c9-dad24d2b48bb.png"/>
 </CenterImg>
 
+BaGetter supports Filesystem, GCP and AWS S3 buckets for package storage, and MySQL, Sqlite, SqlServer and PostgreSQL as database. The current per-package size limit is ~8GB. It can be hosted on IIS, and is also available in a linux [docker image](https://hub.docker.com/r/bagetter/bagetter).
+
 ## Run BaGetter
 
 You can run BaGetter on your preferred platform:

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -188,6 +188,21 @@ This path is configurable if needed:
 }
 ```
 
+## Maximum package size
+
+The max package size default to 8GiB and can be configured using the `MaxPackageSizeGiB` setting. The NuGet gallery currently has a 250MB limit, which is enough for most packages.
+This can be useful if you are hosting a private feed and need to host large packages that include chocolatey installers, machine learning models, etc.
+
+```json
+{
+    ...
+
+    "MaxPackageSizeGiB": 8,
+
+    ...
+}
+```
+
 ## Load secrets from files
 
 Mostly useful when running containerised (e.g. using Docker, Podman, Kubernetes, etc), the application will look for files named in the same pattern as environment variables under `/run/secrets`.

--- a/src/BaGetter.Core/Configuration/BaGetterOptions.cs
+++ b/src/BaGetter.Core/Configuration/BaGetterOptions.cs
@@ -43,6 +43,12 @@ public class BaGetterOptions
     /// </summary>
     public string Urls { get; set; }
 
+    /// <summary>
+    /// The maximum package size in GB.
+    /// Attempted uploads of packages larger than this will be rejected with an internal server error carrying one <see cref="System.IO.InvalidDataException"/>.
+    /// </summary>
+    public uint MaxPackageSizeGiB { get; set; } = 8;
+
     public DatabaseOptions Database { get; set; }
 
     public StorageOptions Storage { get; set; }

--- a/src/BaGetter.Web/BaGetter.Web.csproj
+++ b/src/BaGetter.Web/BaGetter.Web.csproj
@@ -21,6 +21,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\BaGetter.Core\BaGetter.Core.csproj" />
-  </ItemGroup>
+  </ItemGroup>  
 
 </Project>

--- a/src/BaGetter.Web/Extensions/HtmlHelperExtensions.cs
+++ b/src/BaGetter.Web/Extensions/HtmlHelperExtensions.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Text;
+using BaGetter.Web.Helper;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace BaGetter.Web.Extensions;
+
+public static class HtmlHelperExtensions
+{
+    /// <remarks>Based on: <see href="https://github.com/NuGet/NuGetGallery/blob/main/src/NuGetGallery/Views/Shared/Gallery/Layout.cshtml"/></remarks>
+    public static IHtmlContent AddReleaseMetaTags(this IHtmlHelper htmlHelper)
+    {
+        var builder = new StringBuilder();
+
+        var ver = ApplicationVersionHelper.GetVersion();
+        if (ver.Present)
+        {
+            WriteMetaTag(builder, "branch", ver.Branch);
+            WriteMetaTag(builder, "commit", ver.ShortCommit);
+            WriteMetaTag(builder, "time", ver.BuildDateUtc == DateTime.MinValue ? null : ver.BuildDateUtc.ToString("O"));
+        }
+
+        return new HtmlString(builder.ToString());
+    }
+
+    public static IHtmlContent AddReleaseInformationAsComment(this IHtmlHelper htmlHelper)
+    {
+        var builder = new StringBuilder();
+
+        var ver = ApplicationVersionHelper.GetVersion();
+        if (ver.Present)
+        {
+            builder.AppendLine("<!--")
+                .AppendLine($"This is BaGetter version {ver.Version}.");
+
+            if (!string.IsNullOrEmpty(ver.ShortCommit))
+            {
+                var commitUri = ver.CommitUri != null ? ver.CommitUri.AbsoluteUri.Replace("git://github.com", "https://github.com") : string.Empty;
+                builder.AppendLine($"Deployed from {ver.ShortCommit} Link: {commitUri}");
+            }
+
+            if (!string.IsNullOrEmpty(ver.Branch))
+            {
+                var branchUri = ver.BranchUri != null ? ver.BranchUri.AbsoluteUri : string.Empty;
+                builder.AppendLine($"Built on {ver.Branch} Link: {branchUri}");
+            }
+
+            if (ver.BuildDateUtc != DateTime.MinValue)
+            {
+                builder.AppendLine($"Built on {ver.BuildDateUtc.ToString("O")}");
+            }
+
+            builder.AppendLine("-->");
+        }
+
+        return new HtmlString(builder.ToString());
+    }
+
+    private static void WriteMetaTag(StringBuilder builder, string name, string val)
+    {
+        if (!string.IsNullOrEmpty(val))
+        {
+            builder.AppendLine($"<meta name=\"deployment-{name}\" content=\"{val}\" />");
+        }
+    }
+}

--- a/src/BaGetter.Web/Helper/ApplicationVersion.cs
+++ b/src/BaGetter.Web/Helper/ApplicationVersion.cs
@@ -22,6 +22,7 @@ internal class ApplicationVersion
     public string Branch { get; private set; }
     public string Commit { get; private set; }
     public DateTime BuildDateUtc { get; private set; }
+    public string Authors { get; private set; }
 
     // Calculated
     public string ShortCommit { get; private set; }
@@ -37,7 +38,7 @@ internal class ApplicationVersion
         BuildDateUtc = DateTime.UtcNow;
     }
 
-    public ApplicationVersion(Uri repositoryBase, string informationalVersion, string version, string branch, string commit, DateTime buildDateUtc)
+    public ApplicationVersion(Uri repositoryBase, string informationalVersion, string version, string branch, string commit, DateTime buildDateUtc, string authors)
     {
         Present = true;
         InformationalVersion = informationalVersion;
@@ -45,6 +46,7 @@ internal class ApplicationVersion
         Branch = branch;
         Commit = commit;
         BuildDateUtc = buildDateUtc;
+        Authors = authors;
 
         ShortCommit = string.IsNullOrEmpty(Commit) ? string.Empty : Commit.Substring(0, Math.Min(10, Commit.Length));
 

--- a/src/BaGetter.Web/Helper/ApplicationVersion.cs
+++ b/src/BaGetter.Web/Helper/ApplicationVersion.cs
@@ -1,0 +1,77 @@
+using System;
+
+namespace BaGetter.Web.Helper;
+
+internal class ApplicationVersion
+{
+    public static readonly ApplicationVersion Empty = new();
+
+    /// <summary>
+    /// Indicates if all version information was given during build process.
+    /// </summary>
+    public bool Present { get; private set; }
+
+    /// <summary>
+    /// The version e.g. <c>7.8.9</c>
+    /// </summary>
+    public string Version { get; private set; }
+    /// <summary>
+    /// The version with additional information e.g. <c>7.8.9+commitHash</c>
+    /// </summary>
+    public string InformationalVersion { get; private set; }
+    public string Branch { get; private set; }
+    public string Commit { get; private set; }
+    public DateTime BuildDateUtc { get; private set; }
+
+    // Calculated
+    public string ShortCommit { get; private set; }
+    public Uri BranchUri { get; private set; }
+    public Uri CommitUri { get; private set; }
+
+    private ApplicationVersion()
+    {
+        Present = false;
+        Version = "1.0";
+        Branch = string.Empty;
+        Commit = string.Empty;
+        BuildDateUtc = DateTime.UtcNow;
+    }
+
+    public ApplicationVersion(Uri repositoryBase, string informationalVersion, string version, string branch, string commit, DateTime buildDateUtc)
+    {
+        Present = true;
+        InformationalVersion = informationalVersion;
+        Version = version;
+        Branch = branch;
+        Commit = commit;
+        BuildDateUtc = buildDateUtc;
+
+        ShortCommit = string.IsNullOrEmpty(Commit) ? string.Empty : Commit.Substring(0, Math.Min(10, Commit.Length));
+
+        if (repositoryBase != null)
+        {
+            BranchUri = CombineUri(repositoryBase, "tree/" + branch);
+            CommitUri = CombineUri(repositoryBase, "commit/" + ShortCommit);
+        }
+    }
+
+    private static Uri CombineUri(Uri repositoryBase, string relative)
+    {
+        var builder = new UriBuilder(repositoryBase);
+        if (string.IsNullOrEmpty(builder.Path))
+        {
+            builder.Path = relative;
+        }
+        else
+        {
+            if (!builder.Path.EndsWith('/'))
+            {
+                builder.Path += "/";
+            }
+
+            builder.Path += relative;
+        }
+
+        return builder.Uri;
+    }
+}

--- a/src/BaGetter.Web/Helper/ApplicationVersionHelper.cs
+++ b/src/BaGetter.Web/Helper/ApplicationVersionHelper.cs
@@ -20,22 +20,24 @@ internal static class ApplicationVersionHelper
     {
         try
         {
-            var metadata = typeof(ApplicationVersionHelper)
-                .Assembly
+            var assembly = typeof(ApplicationVersionHelper).Assembly;
+            var metadataAttr = assembly
                 .GetCustomAttributes<AssemblyMetadataAttribute>()
                 .ToDictionary(a => a.Key, a => a.Value, StringComparer.OrdinalIgnoreCase);
-            var infoVer = typeof(ApplicationVersionHelper)
-                .Assembly
+            var infoVersionAttr = assembly
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            var companyAttr = assembly
+                .GetCustomAttribute<AssemblyCompanyAttribute>();
 
-            var informationalVersion = infoVer == null ?
+            var informationalVersion = infoVersionAttr == null ?
                 typeof(ApplicationVersionHelper).Assembly.GetName().Version.ToString() :
-                infoVer.InformationalVersion;
+                infoVersionAttr.InformationalVersion;
             var version = informationalVersion.Split("+").First();
-            var branch = TryGet(metadata, "Branch");
-            var commit = TryGet(metadata, "CommitId");
-            var dateString = TryGet(metadata, "BuildDateUtc");
-            var repoUriString = TryGet(metadata, "RepositoryUrl");
+            var authors = companyAttr?.Company ?? string.Empty;
+            var branch = TryGet(metadataAttr, "CommitBranch");
+            var commit = TryGet(metadataAttr, "CommitHash");
+            var dateString = TryGet(metadataAttr, "BuildDateUtc");
+            var repoUriString = TryGet(metadataAttr, "RepositoryUrl");
 
             if (!DateTime.TryParse(dateString, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var buildDate))
             {
@@ -53,7 +55,8 @@ internal static class ApplicationVersionHelper
                 version,
                 branch,
                 commit,
-                buildDate);
+                buildDate,
+                authors);
         }
         catch
         {

--- a/src/BaGetter.Web/Helper/ApplicationVersionHelper.cs
+++ b/src/BaGetter.Web/Helper/ApplicationVersionHelper.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+
+namespace BaGetter.Web.Helper;
+
+/// <remarks>Based on: <see href="https://github.com/NuGet/NuGetGallery/tree/main/src/NuGetGallery/Infrastructure/ApplicationVersionHelper.cs"/></remarks>
+internal static class ApplicationVersionHelper
+{
+    private static readonly Lazy<ApplicationVersion> _version = new(LoadVersion);
+
+    public static ApplicationVersion GetVersion()
+    {
+        return _version.Value;
+    }
+
+    private static ApplicationVersion LoadVersion()
+    {
+        try
+        {
+            var metadata = typeof(ApplicationVersionHelper)
+                .Assembly
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .ToDictionary(a => a.Key, a => a.Value, StringComparer.OrdinalIgnoreCase);
+            var infoVer = typeof(ApplicationVersionHelper)
+                .Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+
+            var informationalVersion = infoVer == null ?
+                typeof(ApplicationVersionHelper).Assembly.GetName().Version.ToString() :
+                infoVer.InformationalVersion;
+            var version = informationalVersion.Split("+").First();
+            var branch = TryGet(metadata, "Branch");
+            var commit = TryGet(metadata, "CommitId");
+            var dateString = TryGet(metadata, "BuildDateUtc");
+            var repoUriString = TryGet(metadata, "RepositoryUrl");
+
+            if (!DateTime.TryParse(dateString, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var buildDate))
+            {
+                buildDate = DateTime.MinValue;
+            }
+
+            if (!Uri.TryCreate(repoUriString, UriKind.Absolute, out var repoUri))
+            {
+                repoUri = null;
+            }
+
+            return new ApplicationVersion(
+                repoUri,
+                informationalVersion,
+                version,
+                branch,
+                commit,
+                buildDate);
+        }
+        catch
+        {
+            return ApplicationVersion.Empty;
+        }
+    }
+
+    private static string TryGet(Dictionary<string, string> metadata, string key)
+    {
+        if (!metadata.TryGetValue(key, out var val))
+        {
+            return string.Empty;
+        }
+
+        return val;
+    }
+}

--- a/src/BaGetter.Web/Pages/Shared/_Layout.cshtml
+++ b/src/BaGetter.Web/Pages/Shared/_Layout.cshtml
@@ -1,3 +1,4 @@
+@using System.Reflection
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -16,7 +17,6 @@
 </head>
 <body>
     <header>
-
         <nav class="navbar navbar-inverse" role="navigation">
             <div class="container">
                 <div class="row">
@@ -60,9 +60,25 @@
         </nav>
     </header>
 
-    <section role="main" class="container main-container">
+    <main role="main" class="container main-container">
         @RenderBody()
-    </section>
+    </main>
+
+    <footer class="footer">
+        <p>Version (Web-Assembly): @typeof(BaGetter.Web.Pages_Index).Assembly.GetName().Version</p>
+        <p>
+            Version (InformationalVersion): @(Assembly.GetEntryAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            .InformationalVersion)
+        </p>
+        <p>
+            Version (InformationalVersion without Hash): @(Assembly.GetEntryAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            .InformationalVersion
+            .Split("+").First())
+        </p>
+
+    </footer>
 
     <script src="~/_content/BaGetter.Web/lib/alpinejs/dist/alpine.js"></script>
 

--- a/src/BaGetter.Web/Pages/Shared/_Layout.cshtml
+++ b/src/BaGetter.Web/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,5 @@
 @using System.Reflection
+@using BaGetter.Web.Extensions
 @using BaGetter.Web.Helper
 <!DOCTYPE html>
 <html lang="en">
@@ -7,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="BaGet">
     <meta name="author" content="@ApplicationVersionHelper.GetVersion().Authors">
-    @ReleaseMetadata()
+    @Html.AddReleaseMetaTags()
 
     <link rel="shortcut icon" href="~/_content/BaGetter.Web/favicon.ico">
 
@@ -70,6 +71,7 @@
         <p>
             Version: @ApplicationVersionHelper.GetVersion().Version
         </p>
+        @Html.AddReleaseInformationAsComment()
     </footer>
 
     <script src="~/_content/BaGetter.Web/lib/alpinejs/dist/alpine.js"></script>
@@ -81,27 +83,3 @@
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>
-
-@{
-    //based on: https://github.com/NuGet/NuGetGallery/blob/main/src/NuGetGallery/Views/Shared/Gallery/Layout.cshtml
-    object ReleaseMetadata()
-    {
-        var ver = ApplicationVersionHelper.GetVersion();
-        if (ver.Present)
-        {
-            WriteMeta("branch", ver.Branch);
-            WriteMeta("commit", ver.ShortCommit);
-            WriteMeta("time", ver.BuildDateUtc == DateTime.MinValue ? null : ver.BuildDateUtc.ToString("O"));
-        }
-
-        return null;
-    }
-
-    void WriteMeta(string name, string val)
-    {
-        if (!string.IsNullOrEmpty(val))
-        {
-            <meta name="deployment-@name" content="@val" />
-        }
-    }
-}

--- a/src/BaGetter.Web/Pages/Shared/_Layout.cshtml
+++ b/src/BaGetter.Web/Pages/Shared/_Layout.cshtml
@@ -1,11 +1,13 @@
 @using System.Reflection
+@using BaGetter.Web.Helper
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="BaGet">
-    <meta name="author" content="Loic Sharma">
+    <meta name="author" content="@ApplicationVersionHelper.GetVersion().Authors">
+    @ReleaseMetadata()
 
     <link rel="shortcut icon" href="~/_content/BaGetter.Web/favicon.ico">
 
@@ -64,14 +66,10 @@
         @RenderBody()
     </main>
 
-    <footer class="footer">        
+    <footer class="footer">
         <p>
-            Version: @(Assembly.GetEntryAssembly()
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-            .InformationalVersion
-            .Split("+").First())
+            Version: @ApplicationVersionHelper.GetVersion().Version
         </p>
-
     </footer>
 
     <script src="~/_content/BaGetter.Web/lib/alpinejs/dist/alpine.js"></script>
@@ -83,3 +81,27 @@
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>
+
+@{
+    //based on: https://github.com/NuGet/NuGetGallery/blob/main/src/NuGetGallery/Views/Shared/Gallery/Layout.cshtml
+    object ReleaseMetadata()
+    {
+        var ver = ApplicationVersionHelper.GetVersion();
+        if (ver.Present)
+        {
+            WriteMeta("branch", ver.Branch);
+            WriteMeta("commit", ver.ShortCommit);
+            WriteMeta("time", ver.BuildDateUtc == DateTime.MinValue ? null : ver.BuildDateUtc.ToString("O"));
+        }
+
+        return null;
+    }
+
+    void WriteMeta(string name, string val)
+    {
+        if (!string.IsNullOrEmpty(val))
+        {
+            <meta name="deployment-@name" content="@val" />
+        }
+    }
+}

--- a/src/BaGetter.Web/Pages/Shared/_Layout.cshtml
+++ b/src/BaGetter.Web/Pages/Shared/_Layout.cshtml
@@ -64,15 +64,9 @@
         @RenderBody()
     </main>
 
-    <footer class="footer">
-        <p>Version (Web-Assembly): @typeof(BaGetter.Web.Pages_Index).Assembly.GetName().Version</p>
+    <footer class="footer">        
         <p>
-            Version (InformationalVersion): @(Assembly.GetEntryAssembly()
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-            .InformationalVersion)
-        </p>
-        <p>
-            Version (InformationalVersion without Hash): @(Assembly.GetEntryAssembly()
+            Version: @(Assembly.GetEntryAssembly()
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             .InformationalVersion
             .Split("+").First())

--- a/src/BaGetter.Web/wwwroot/css/site.css
+++ b/src/BaGetter.Web/wwwroot/css/site.css
@@ -24,8 +24,12 @@ main {
 
 .footer {
   flex-shrink: 0;
-  background-color: #d3d3d3;
-  text-align: center;
+  background-color: #d3d3d3;  
+}
+
+.footer p {
+  text-align: center;    
+  vertical-align: middle;    
 }
 
 h1,

--- a/src/BaGetter.Web/wwwroot/css/site.css
+++ b/src/BaGetter.Web/wwwroot/css/site.css
@@ -3,11 +3,29 @@ for details on configuring this project to bundle and minify static web assets. 
 
 /* Layout
 -------------------------------------------------- */
+
+html {
+  height: 100%;
+}
+
 body {
+  height: 100%;
   margin: 0;
   padding: 0;
   font-family: "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 16px;
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  flex: 1;
+}
+
+.footer {
+  flex-shrink: 0;
+  background-color: #d3d3d3;
+  text-align: center;
 }
 
 h1,

--- a/src/BaGetter/ConfigureBaGetterServer.cs
+++ b/src/BaGetter/ConfigureBaGetterServer.cs
@@ -1,0 +1,54 @@
+using BaGetter.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Options;
+
+namespace BaGetter;
+
+public class ConfigureBaGetterServer
+    : IConfigureOptions<CorsOptions>
+    , IConfigureOptions<FormOptions>
+    , IConfigureOptions<ForwardedHeadersOptions>
+    , IConfigureOptions<IISServerOptions>
+{
+    public const string CorsPolicy = "AllowAll";
+    private readonly BaGetterOptions _baGetterOptions;
+
+    public ConfigureBaGetterServer(IOptions<BaGetterOptions> baGetterOptions)
+    {
+        _baGetterOptions = baGetterOptions.Value;
+    }
+
+
+    public void Configure(CorsOptions options)
+    {
+        // TODO: Consider disabling this on production builds.
+        options.AddPolicy(
+            CorsPolicy,
+            builder => builder.AllowAnyOrigin()
+                .AllowAnyMethod()
+                .AllowAnyHeader());
+    }
+
+    public void Configure(FormOptions options)
+    {
+        // Allow packages up to ~8GiB in size
+        options.MultipartBodyLengthLimit = (long) _baGetterOptions.MaxPackageSizeGiB * int.MaxValue / 2;
+    }
+
+    public void Configure(ForwardedHeadersOptions options)
+    {
+        options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+
+        // Do not restrict to local network/proxy
+        options.KnownNetworks.Clear();
+        options.KnownProxies.Clear();
+    }
+
+    public void Configure(IISServerOptions options)
+    {
+        options.MaxRequestBodySize = (long)_baGetterOptions.MaxPackageSizeGiB * int.MaxValue / 2;
+    }
+}

--- a/src/BaGetter/Startup.cs
+++ b/src/BaGetter/Startup.cs
@@ -24,7 +24,8 @@ public class Startup
 
     public void ConfigureServices(IServiceCollection services)
     {
-        services.ConfigureOptions<ConfigureBaGetterOptions>();
+        services.ConfigureOptions<ValidateBaGetterOptions>();
+        services.ConfigureOptions<ConfigureBaGetterServer>();
 
         services.AddBaGetterOptions<IISServerOptions>(nameof(IISServerOptions));
         services.AddBaGetterWebApplication(ConfigureBaGetterApplication);
@@ -82,7 +83,7 @@ public class Startup
         app.UseStaticFiles();
         app.UseRouting();
 
-        app.UseCors(ConfigureBaGetterOptions.CorsPolicy);
+        app.UseCors(ConfigureBaGetterServer.CorsPolicy);
         app.UseOperationCancelledMiddleware();
 
         app.UseEndpoints(endpoints =>

--- a/src/BaGetter/ValidateBaGetterOptions.cs
+++ b/src/BaGetter/ValidateBaGetterOptions.cs
@@ -14,15 +14,9 @@ namespace BaGetter;
 /// BaGetter's options configuration, specific to the default BaGetter application.
 /// Don't use this if you are embedding BaGetter into your own custom ASP.NET Core application.
 /// </summary>
-public class ConfigureBaGetterOptions
-    : IConfigureOptions<CorsOptions>
-    , IConfigureOptions<FormOptions>
-    , IConfigureOptions<ForwardedHeadersOptions>
-    , IConfigureOptions<IISServerOptions>
-    , IValidateOptions<BaGetterOptions>
+public class ValidateBaGetterOptions
+    : IValidateOptions<BaGetterOptions>
 {
-    public const string CorsPolicy = "AllowAll";
-
     private static readonly HashSet<string> ValidDatabaseTypes
         = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -51,35 +45,6 @@ public class ConfigureBaGetterOptions
             "Database",
             "Null",
         };
-
-    public void Configure(CorsOptions options)
-    {
-        // TODO: Consider disabling this on production builds.
-        options.AddPolicy(
-            CorsPolicy,
-            builder => builder.AllowAnyOrigin()
-                .AllowAnyMethod()
-                .AllowAnyHeader());
-    }
-
-    public void Configure(FormOptions options)
-    {
-        options.MultipartBodyLengthLimit = int.MaxValue;
-    }
-
-    public void Configure(ForwardedHeadersOptions options)
-    {
-        options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
-
-        // Do not restrict to local network/proxy
-        options.KnownNetworks.Clear();
-        options.KnownProxies.Clear();
-    }
-
-    public void Configure(IISServerOptions options)
-    {
-        options.MaxRequestBodySize = 262144000;
-    }
 
     public ValidateOptionsResult Validate(string name, BaGetterOptions options)
     {

--- a/src/BaGetter/appsettings.json
+++ b/src/BaGetter/appsettings.json
@@ -2,6 +2,7 @@
   "ApiKey": "",
   "PackageDeletionBehavior": "Unlist",
   "AllowPackageOverwrites": false,
+  "MaxPackageSizeGiB": 8,
 
   "Database": {
     "Type": "Sqlite",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,8 @@
     <PackageIcon>packageIcon.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageVersion Condition="'$(PackageVersion)' == ''">0.1.0-prerelease</PackageVersion>
-    <PackageProjectUrl>https://www.bagetter.com</PackageProjectUrl>
+    <PackageProjectUrl>https://www.bagetter.com</PackageProjectUrl>    
+    <Version>7.8.9</Version>    
   </PropertyGroup>
 
   <!-- Compiler properties -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,14 +3,13 @@
   <!-- Package properties -->
   <PropertyGroup>
     <Authors>Community https://github.com/bagetter/BaGetter; Loic Sharma</Authors>
-    <Copyright>Copyright (c) BaGetter 2023</Copyright>
+    <Copyright>Copyright (c) BaGetter $([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <Product>BaGetter</Product>
 
     <PackageIcon>packageIcon.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageVersion Condition="'$(PackageVersion)' == ''">0.1.0-prerelease</PackageVersion>
-    <PackageProjectUrl>https://www.bagetter.com</PackageProjectUrl>    
-    <Version>7.8.9</Version>    
+    <PackageProjectUrl>https://www.bagetter.com</PackageProjectUrl>
   </PropertyGroup>
 
   <!-- Compiler properties -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,30 @@
+<Project>
+
+  <PropertyGroup>
+    <!--Azure Pipelines-->
+    <CommitBranch Condition=" '$(CommitBranch)' == '' ">$(BUILD_SOURCEBRANCHNAME)</CommitBranch>
+    <CommitHash Condition=" '$(CommitHash)' == '' ">$(BUILD_SOURCEVERSION)</CommitHash>
+    <!--GitHub Actions-->
+    <CommitBranch Condition=" '$(CommitBranch)' == '' and '$(GITHUB_REF_NAME)' != '' ">$(GITHUB_REF_NAME)</CommitBranch>
+    <CommitHash Condition=" '$(CommitHash)' == '' ">$(GITHUB_SHA)</CommitHash>
+  </PropertyGroup>
+
+  <Target Name="AddGitMetadaAssemblyAttributes" BeforeTargets="GetAssemblyAttributes">
+
+    <!--Executes the Git Commands to get the Hash and Branch-->
+    <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low" IgnoreExitCode="true" Condition=" '$(CommitHash)' == '' ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="CommitHash" />
+    </Exec>
+    <Exec Command="git rev-parse --abbrev-ref HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low" IgnoreExitCode="true" Condition=" '$(CommitBranch)' == '' ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="CommitBranch" />
+    </Exec>
+
+    <!--Generates the ItemGroup and all AssemblyMetadata Tags-->
+    <ItemGroup>
+      <AssemblyMetadata Include="BuildDateUtc" Value="$([System.DateTime]::UtcNow.ToString(o))" />
+      <AssemblyMetadata Condition=" $(CommitHash) != '' " Include="CommitHash" Value="$(CommitHash)" />
+      <AssemblyMetadata Condition=" $(CommitBranch) != '' " Include="CommitBranch" Value="$(CommitBranch)" />
+    </ItemGroup>
+
+  </Target>
+</Project>


### PR DESCRIPTION
This PR adds a footer to the Website displaying the current running version of BaGetter.
This fixes a part of the requests from #102.

Current state:

![grafik](https://github.com/bagetter/BaGetter/assets/6222752/6ce91d90-3f78-42eb-9755-97ed481d07f1)

**Todo**

Currently there is no version assigned to the binaries of BaGetter. So `1.0.0.0` is always shown.

- [x] add version to BaGetter -> this is done by PR #113 