### PR TITLE
Fix serialization of `SearchResult`

### DIFF
--- a/src/BaGetter.Protocol/Models/SearchResult.cs
+++ b/src/BaGetter.Protocol/Models/SearchResult.cs
@@ -76,6 +76,7 @@ public class SearchResult
     /// The tags of the matched package.
     /// </summary>
     [JsonPropertyName("tags")]
+    [JsonConverter(typeof(StringOrStringArrayJsonConverter))]
     public IReadOnlyList<string> Tags { get; set; }
 
     /// <summary>

--- a/tests/BaGetter.Protocol.Tests/Models/PackageMetadataTests.cs
+++ b/tests/BaGetter.Protocol.Tests/Models/PackageMetadataTests.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using BaGetter.Protocol.Internal;
 using BaGetter.Protocol.Models;
 using Xunit;
 
@@ -12,7 +11,6 @@ public class PackageMetadataTests
     public PackageMetadataTests()
     {
         _serializerOptions = new JsonSerializerOptions();
-        _serializerOptions.Converters.Add(new StringOrStringArrayJsonConverter());
     }
 
     [Fact]
@@ -146,5 +144,4 @@ public class PackageMetadataTests
         Assert.NotNull(result.Tags);
         Assert.Equal(2, result.Tags.Count);
     }
-
 }

--- a/tests/BaGetter.Protocol.Tests/Models/SearchResultTests.cs
+++ b/tests/BaGetter.Protocol.Tests/Models/SearchResultTests.cs
@@ -1,0 +1,351 @@
+using System.Text.Json;
+using BaGetter.Protocol.Models;
+using Xunit;
+
+namespace BaGetter.Protocol.Tests.Models;
+
+public class SearchResultTests
+{
+    private readonly JsonSerializerOptions _serializerOptions;
+
+    public SearchResultTests()
+    {
+        _serializerOptions = new JsonSerializerOptions();
+    }
+
+    #region Tags
+
+    [Fact]
+    public void Tags_EmptyArray_ShouldDeserialize()
+    {
+        // Arrange
+        var stringToDeserialize = """
+        {
+            "id": "https://nuget.pkg.github.com/FakeOrga/fakepkg/1.5.1.json",
+            "version": "1.5.1",
+            "description": "Package Description",
+            "authors": [ "Someone" ],
+            "iconUrl": "",
+            "licenseUrl": "",
+            "packageTypes": [
+                {
+                    "name": "myPackageType"
+                }
+            ],
+            "projectUrl": "",
+            "registration": "",
+            "summary": "",
+            "tags": [ ],
+            "title": "",
+            "totalDownloads": 0,
+            "versions": [
+                {
+                    "@id": "",
+                    "version": "",
+                    "downloads": 0
+                }
+            ]
+        }
+        """;
+
+        // Act
+        var result = JsonSerializer.Deserialize<SearchResult>(stringToDeserialize, _serializerOptions);
+
+        // Assert
+        Assert.NotNull(result.Tags);
+        Assert.Empty(result.Tags);
+    }
+
+    [Fact]
+    public void Tags_EmptyString_ShouldDeserialize()
+    {
+        // Arrange
+        var stringToDeserialize = """
+        {
+            "id": "https://nuget.pkg.github.com/FakeOrga/fakepkg/1.5.1.json",
+            "version": "1.5.1",
+            "description": "Package Description",
+            "authors": [ "Someone" ],
+            "iconUrl": "",
+            "licenseUrl": "",
+            "packageTypes": [
+                {
+                    "name": "myPackageType"
+                }
+            ],
+            "projectUrl": "",
+            "registration": "",
+            "summary": "",
+            "tags": "",
+            "title": "",
+            "totalDownloads": 0,
+            "versions": [
+                {
+                    "@id": "",
+                    "version": "",
+                    "downloads": 0
+                }
+            ]
+        }
+        """;
+
+        // Act
+        var result = JsonSerializer.Deserialize<SearchResult>(stringToDeserialize, _serializerOptions);
+
+        // Assert
+        Assert.NotNull(result.Tags);
+        Assert.Single(result.Tags);
+    }
+
+    [Fact]
+    public void Tags_SingleEntry_ShouldDeserializeSingleTag()
+    {
+        // Arrange
+        var stringToDeserialize = """
+        {
+            "id": "https://nuget.pkg.github.com/FakeOrga/fakepkg/1.5.1.json",
+            "version": "1.5.1",
+            "description": "Package Description",
+            "authors": [ "Someone" ],
+            "iconUrl": "",
+            "licenseUrl": "",
+            "packageTypes": [
+                {
+                    "name": "myPackageType"
+                }
+            ],
+            "projectUrl": "",
+            "registration": "",
+            "summary": "",
+            "tags": "tag1",
+            "title": "",
+            "totalDownloads": 0,
+            "versions": [
+                {
+                    "@id": "",
+                    "version": "",
+                    "downloads": 0
+                }
+            ]
+        }
+        """;
+
+        // Act
+        var result = JsonSerializer.Deserialize<SearchResult>(stringToDeserialize, _serializerOptions);
+
+        // Assert
+        Assert.NotNull(result.Tags);
+        Assert.Single(result.Tags);
+    }
+
+    [Fact]
+    public void Tags_HasMultipleEntries_ShouldDeserializeMultipleTags()
+    {
+        // Arrange
+        var stringToDeserialize = """
+        {
+            "id": "https://nuget.pkg.github.com/FakeOrga/fakepkg/1.5.1.json",
+            "version": "1.5.1",
+            "description": "Package Description",
+            "authors": [ "Someone" ],
+            "iconUrl": "",
+            "licenseUrl": "",
+            "packageTypes": [
+                {
+                    "name": "myPackageType"
+                }
+            ],
+            "projectUrl": "",
+            "registration": "",
+            "summary": "",
+            "tags": [ "tag1", "tag2"],
+            "title": "",
+            "totalDownloads": 0,
+            "versions": [
+                {
+                    "@id": "",
+                    "version": "",
+                    "downloads": 0
+                }
+            ]
+        }
+        """;
+
+        // Act
+        var result = JsonSerializer.Deserialize<SearchResult>(stringToDeserialize, _serializerOptions);
+
+        // Assert
+        Assert.NotNull(result.Tags);
+        Assert.Equal(2, result.Tags.Count);
+    }
+
+    #endregion
+
+    #region Authors
+
+    [Fact]
+    public void Authors_EmptyArray_ShouldDeserialize()
+    {
+        // Arrange
+        var stringToDeserialize = """
+        {
+            "id": "https://nuget.pkg.github.com/FakeOrga/fakepkg/1.5.1.json",
+            "version": "1.5.1",
+            "description": "Package Description",
+            "authors": [ ],
+            "iconUrl": "",
+            "licenseUrl": "",
+            "packageTypes": [
+                {
+                    "name": "myPackageType"
+                }
+            ],
+            "projectUrl": "",
+            "registration": "",
+            "summary": "",
+            "tags": [ "tag1" ],
+            "title": "",
+            "totalDownloads": 0,
+            "versions": [
+                {
+                    "@id": "",
+                    "version": "",
+                    "downloads": 0
+                }
+            ]
+        }
+        """;
+
+        // Act
+        var result = JsonSerializer.Deserialize<SearchResult>(stringToDeserialize, _serializerOptions);
+
+        // Assert
+        Assert.NotNull(result.Authors);
+        Assert.Empty(result.Authors);
+    }
+
+    [Fact]
+    public void Authors_EmptyString_ShouldDeserialize()
+    {
+        // Arrange
+        var stringToDeserialize = """
+         {
+             "id": "https://nuget.pkg.github.com/FakeOrga/fakepkg/1.5.1.json",
+             "version": "1.5.1",
+             "description": "Package Description",
+             "authors": "",
+             "iconUrl": "",
+             "licenseUrl": "",
+             "packageTypes": [
+                 {
+                     "name": "myPackageType"
+                 }
+             ],
+             "projectUrl": "",
+             "registration": "",
+             "summary": "",
+             "tags": [ "tag1" ],
+             "title": "",
+             "totalDownloads": 0,
+             "versions": [
+                 {
+                     "@id": "",
+                     "version": "",
+                     "downloads": 0
+                 }
+             ]
+         }
+         """;
+
+        // Act
+        var result = JsonSerializer.Deserialize<SearchResult>(stringToDeserialize, _serializerOptions);
+
+        // Assert
+        Assert.NotNull(result.Authors);
+        Assert.Single(result.Authors);
+    }
+
+    [Fact]
+    public void Authors_SingleEntry_ShouldDeserializeSingleAuthor()
+    {
+        // Arrange
+        var stringToDeserialize = """
+        {
+            "id": "https://nuget.pkg.github.com/FakeOrga/fakepkg/1.5.1.json",
+            "version": "1.5.1",
+            "description": "Package Description",
+            "authors": [ "Someone" ],
+            "iconUrl": "",
+            "licenseUrl": "",
+            "packageTypes": [
+                {
+                    "name": "myPackageType"
+                }
+            ],
+            "projectUrl": "",
+            "registration": "",
+            "summary": "",
+            "tags": [ "tag1" ],
+            "title": "",
+            "totalDownloads": 0,
+            "versions": [
+                {
+                    "@id": "",
+                    "version": "",
+                    "downloads": 0
+                }
+            ]
+        }
+        """;
+
+        // Act
+        var result = JsonSerializer.Deserialize<SearchResult>(stringToDeserialize, _serializerOptions);
+
+        // Assert
+        Assert.NotNull(result.Authors);
+        Assert.Single(result.Authors);
+    }
+
+    [Fact]
+    public void Authors_HasMultipleEntries_ShouldDeserializeMultipleAuthors()
+    {
+        // Arrange
+        var stringToDeserialize = """
+        {
+            "id": "https://nuget.pkg.github.com/FakeOrga/fakepkg/1.5.1.json",
+            "version": "1.5.1",
+            "description": "Package Description",
+            "authors": [ "Someone", "Another Author" ],
+            "iconUrl": "",
+            "licenseUrl": "",
+            "packageTypes": [
+                {
+                    "name": "myPackageType"
+                }
+            ],
+            "projectUrl": "",
+            "registration": "",
+            "summary": "",
+            "tags": [ "tag1"],
+            "title": "",
+            "totalDownloads": 0,
+            "versions": [
+                {
+                    "@id": "",
+                    "version": "",
+                    "downloads": 0
+                }
+            ]
+        }
+        """;
+
+        // Act
+        var result = JsonSerializer.Deserialize<SearchResult>(stringToDeserialize, _serializerOptions);
+
+        // Assert
+        Assert.NotNull(result.Authors);
+        Assert.Equal(2, result.Authors.Count);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
As pointed out by @Splamy (via discord) the [official documentation](https://docs.microsoft.com/nuget/api/search-query-service-resource#search-result) states that `Tags` (and `Authors`) can be 
> string or array of strings

This PR fixes that for `Tags` (including tests) and also adds the tests for `Authors`.
Also I noticed false positives in the tests for `PackageMetadata` (my fault) which I fixed.