### PR TITLE
Add readme to nuget packages

### DIFF
--- a/src/BaGetter.Aliyun/BaGetter.Aliyun.csproj
+++ b/src/BaGetter.Aliyun/BaGetter.Aliyun.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    
     <PackageTags>NuGet;Alibaba;Cloud</PackageTags>
     <Description>The libraries to host BaGetter on Alibaba Cloud (Aliyun).</Description>
-    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGetter.Core/BaGetter.Core.csproj
+++ b/src/BaGetter.Core/BaGetter.Core.csproj
@@ -4,6 +4,7 @@
 
     <PackageTags>NuGet</PackageTags>
     <Description>The core libraries that power BaGetter.</Description>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGetter.Database.MySql/BaGetter.Database.MySql.csproj
+++ b/src/BaGetter.Database.MySql/BaGetter.Database.MySql.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <PackageTags>NuGet</PackageTags>
     <Description>The libraries to host BaGetter on MySQL.</Description>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGetter.Database.MySql/BaGetter.Database.MySql.csproj
+++ b/src/BaGetter.Database.MySql/BaGetter.Database.MySql.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+
     <PackageTags>NuGet</PackageTags>
     <Description>The libraries to host BaGetter on MySQL.</Description>
     <PackageReadmeFile>readme.md</PackageReadmeFile>

--- a/src/BaGetter.Database.PostgreSql/BaGetter.Database.PostgreSql.csproj
+++ b/src/BaGetter.Database.PostgreSql/BaGetter.Database.PostgreSql.csproj
@@ -5,6 +5,7 @@
 
     <PackageTags>NuGet</PackageTags>
     <Description>The libraries to host BaGetter on PostgreSQL.</Description>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGetter.Database.SqlServer/BaGetter.Database.SqlServer.csproj
+++ b/src/BaGetter.Database.SqlServer/BaGetter.Database.SqlServer.csproj
@@ -5,6 +5,7 @@
 
     <PackageTags>NuGet</PackageTags>
     <Description>The libraries to host BaGetter on SQL Server.</Description>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGetter.Database.Sqlite/BaGetter.Database.Sqlite.csproj
+++ b/src/BaGetter.Database.Sqlite/BaGetter.Database.Sqlite.csproj
@@ -3,8 +3,10 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
+
     <PackageTags>NuGet</PackageTags>
     <Description>The libraries to host BaGetter on SQLite.</Description>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGetter.Protocol/BaGetter.Protocol.csproj
+++ b/src/BaGetter.Protocol/BaGetter.Protocol.csproj
@@ -5,6 +5,7 @@
 
     <PackageTags>NuGet;Protocol</PackageTags>
     <Description>Libraries to interact with NuGet server APIs.</Description>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BaGetter/BaGetter.csproj
+++ b/src/BaGetter/BaGetter.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -43,4 +43,8 @@
     <None Include="../packageIcon.png" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(PackageReadmeFile)' != '' ">
+    <None Include="$(DefiningProjectDirectory)$(PackageReadmeFile)" Pack="True" PackagePath="" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR adds the already existing `readme` files of the various packages to those packages.
Currently only the `description` is displayed in the official gallery.

## example images (from BaGetter gallery)

### before
![grafik](https://github.com/bagetter/BaGetter/assets/6222752/7a1b29d3-191b-4f28-b41e-af6ab9e65ba7)

### after
![grafik](https://github.com/bagetter/BaGetter/assets/6222752/923734e3-3fbb-44f5-965e-1369fbed6dd2)