### PR TITLE
Include version in Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,3 +106,5 @@ jobs:
           tags: |
             bagetter/bagetter:latest
             bagetter/bagetter:${{ needs.version.outputs.RELEASE_VERSION }}
+          build-args: |
+            Version=${{ needs.version.outputs.RELEASE_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
+ARG Version=1.0.0
+
 FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
+ARG Version
 WORKDIR /src
 
 ## Create separate layer for `dotnet restore` to allow for caching; useful for local development
@@ -13,12 +16,14 @@ RUN dotnet restore BaGetter/BaGetter.csproj
 
 ## Publish app (implicitly builds the app)
 FROM build AS publish
+ARG Version
 # copy all files
 COPY /src .
 RUN dotnet publish BaGetter \
     --configuration Release \
     --output /app \
     --no-restore \
+    -p Version=${Version} \
     -p DebugType=none \
     -p DebugSymbols=false \
     -p GenerateDocumentationFile=false \


### PR DESCRIPTION
Passes the assembly version to the `dotnet publish` step inside the Dockerfile.

Example manual build of this PR:
- `docker build -t local-bagetter:1.1.1-test --build-arg Version=1.1.1-test .`
- `docker run --rm -p 8080:8080 local-bagetter:1.1.1-test`
![image](https://github.com/bagetter/BaGetter/assets/14317886/9e92bc80-3503-4a48-9281-b7a9c979dd78)

Addresses #122