### PR TITLE
feat(Statistics): Show full version

### DIFF
--- a/src/BaGetter.Web/Extensions/IServiceCollectionExtensions.cs
+++ b/src/BaGetter.Web/Extensions/IServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text.Json.Serialization;
 using BaGetter.Core;
 using BaGetter.Web;
+using BaGetter.Web.Helper;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace BaGetter;
@@ -26,6 +27,7 @@ public static class IServiceCollectionExtensions
         services.AddHttpContextAccessor();
         services.AddTransient<IUrlGenerator, BaGetterUrlGenerator>();
 
+        services.AddSingleton(ApplicationVersionHelper.GetVersion());
         services.AddBaGetterApplication(configureAction);
 
         return services;

--- a/src/BaGetter.Web/Helper/ApplicationVersionHelper.cs
+++ b/src/BaGetter.Web/Helper/ApplicationVersionHelper.cs
@@ -29,9 +29,9 @@ internal static class ApplicationVersionHelper
             var companyAttr = assembly
                 .GetCustomAttribute<AssemblyCompanyAttribute>();
 
-            var informationalVersion = infoVersionAttr == null ?
-                typeof(ApplicationVersionHelper).Assembly.GetName().Version.ToString() :
-                infoVersionAttr.InformationalVersion;
+            var informationalVersion = infoVersionAttr?.InformationalVersion
+                ?? typeof(ApplicationVersionHelper).Assembly.GetName().Version?.ToString()
+                ?? string.Empty;
             var version = informationalVersion.Split("+").First();
             var authors = companyAttr?.Company ?? string.Empty;
             var branch = TryGet(metadataAttr, "CommitBranch");

--- a/src/BaGetter.Web/Pages/Shared/_Layout.cshtml
+++ b/src/BaGetter.Web/Pages/Shared/_Layout.cshtml
@@ -3,7 +3,8 @@
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @using Microsoft.Extensions.Options
 
-@inject IOptionsSnapshot<BaGetterOptions> options
+@inject IOptionsSnapshot<BaGetterOptions> Options
+@inject ApplicationVersion Version
 
 <!DOCTYPE html>
 <html lang="en">
@@ -11,7 +12,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="BaGet">
-    <meta name="author" content="@ApplicationVersionHelper.GetVersion().Authors">
+    <meta name="author" content="@Version.Authors">
     @Html.AddReleaseMetaTags()
 
     <link rel="shortcut icon" href="~/_content/BaGetter.Web/favicon.ico">
@@ -31,7 +32,7 @@
                         <ul class="nav navbar-nav" role="tablist">
                             <li role="presentation"><a asp-area="" asp-page="/Index" role="tab" nav-link><span>Packages</span></a></li>
                             <li role="presentation"><a asp-area="" asp-page="/Upload" role="tab" nav-link><span>Upload</span></a></li>
-                            @if (options.Value.Statistics.EnableStatisticsPage)
+                            @if (Options.Value.Statistics.EnableStatisticsPage)
                             {
                                 <li role="presentation"><a asp-area="" asp-page="/Statistics" role="tab" nav-link><span>Statistics</span></a></li>
                             }
@@ -77,7 +78,7 @@
 
     <footer class="footer">
         <p>
-            Version: @ApplicationVersionHelper.GetVersion().Version
+            Version: @Version.Version
         </p>
         @Html.AddReleaseInformationAsComment()
     </footer>

--- a/src/BaGetter.Web/Pages/Statistics.cshtml
+++ b/src/BaGetter.Web/Pages/Statistics.cshtml
@@ -1,13 +1,14 @@
-﻿@page "/stats"
+@page "/stats"
 
 @model StatisticsModel
 
-@using System.Reflection
 @using BaGetter.Core.Statistics
+@using BaGetter.Web.Helper
 @using Microsoft.Extensions.Options
 
-@inject IOptionsSnapshot<BaGetterOptions> options
-@inject IStatisticsService IStatisticsService
+@inject IOptionsSnapshot<BaGetterOptions> Options
+@inject IStatisticsService StatisticsService
+@inject ApplicationVersion Version
 
 @{
     ViewData["Title"] = "Stats";
@@ -21,7 +22,7 @@
             <h4>Current version</h4>
         </article>
         <div class="col-sm-8">
-            <h4>@Assembly.GetExecutingAssembly().GetName().Version</h4>
+            <h4>@Version.InformationalVersion</h4>
         </div>
     </div>
     <div class="row">
@@ -29,7 +30,7 @@
             <h4>Total amount of packages</h4>
         </article>
         <div class="col-sm-8">
-            <h4>@await IStatisticsService.GetPackagesTotalAmount()</h4>
+            <h4>@await StatisticsService.GetPackagesTotalAmount()</h4>
         </div>
     </div>
     <div class="row">
@@ -37,17 +38,17 @@
             <h4>Total amount of package versions</h4>
         </article>
         <div class="col-sm-8">
-            <h4>@await IStatisticsService.GetVersionsTotalAmount()</h4>
+            <h4>@await StatisticsService.GetVersionsTotalAmount()</h4>
         </div>
     </div>
-    @if (options.Value.Statistics.ListConfiguredServices)
+    @if (Options.Value.Statistics.ListConfiguredServices)
     {
         <div class="row">
             <article class="col-sm-4">
                 <h4>Services in use</h4>
             </article>
             <div class="col-sm-8">
-                <h4>@string.Join(", ", IStatisticsService.GetKnownServices())</h4>
+                <h4>@string.Join(", ", StatisticsService.GetKnownServices())</h4>
             </div>
         </div>
     }


### PR DESCRIPTION
Currently the statistics page only shows the numbers part of the version, e.g. 1.1.1, instead of the full version shown in the footer. This PR injects the `ApplicationVersion` object from the footer in order to use the same data source and shows the full version including commit hash.

There's also less reflection this way.