### PR TITLE
feat(Storage): Add Azure Blob Storage provider

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="Azure.Search.Documents" Version="11.5.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.19.1" />
+    <PackageVersion Include="Azure.Storage.Common" Version="12.18.1" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.3" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.38.1" />

--- a/docs/docs/Index.md
+++ b/docs/docs/Index.md
@@ -16,7 +16,7 @@ BaGetter (pronounced "ba getter") is a lightweight NuGet and symbol server. It i
   <img width="100%" src="https://user-images.githubusercontent.com/737941/50140219-d8409700-0258-11e9-94c9-dad24d2b48bb.png"/>
 </CenterImg>
 
-BaGetter supports Filesystem, GCP and AWS S3 buckets for package storage, and MySQL, Sqlite, SqlServer and PostgreSQL as database. The current per-package size limit is ~8GB. It can be hosted on IIS, and is also available in a linux [docker image](https://hub.docker.com/r/bagetter/bagetter).
+BaGetter supports Filesystem, GCP and AWS S3 buckets, and Azure Blob Storage for package storage, and MySQL, Sqlite, SqlServer and PostgreSQL as database. The current per-package size limit is ~8GB. It can be hosted on IIS, and is also available in a linux [docker image](https://hub.docker.com/r/bagetter/bagetter).
 
 ## Run BaGetter
 

--- a/docs/docs/Installation/azure.md
+++ b/docs/docs/Installation/azure.md
@@ -1,3 +1,6 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Run BaGetter on Azure
 
 :::warning
@@ -6,7 +9,7 @@ This page is a work in progress!
 
 :::
 
-Use Azure to scale BaGetter. You can store metadata on [Azure SQL Database](https://azure.microsoft.com/en-us/services/sql-database/), upload packages to [Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/), and provide powerful search using [Azure Search](https://azure.microsoft.com/en-us/services/search/).
+Use Azure to scale BaGetter. You can store metadata on [Azure SQL Database](https://azure.microsoft.com/products/azure-sql/database/), upload packages to [Azure Blob Storage](https://azure.microsoft.com/products/storage/blobs/), and soon provide powerful search using [Azure Search](https://azure.microsoft.com/en-us/services/search/).
 
 ## TODO
 
@@ -16,11 +19,11 @@ Use Azure to scale BaGetter. You can store metadata on [Azure SQL Database](http
 
 ## Configure BaGetter
 
-You can modify BaGetter's configurations by editing the `appsettings.json` file. For the full list of configurations, please refer to [BaGetter's configuration](../configuration.md) guide.
+You can modify BaGetter's configurations by editing the `appsettings.json` file or through [environment variables](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-8.0#non-prefixed-environment-variables). For the full list of configurations, please refer to [BaGetter's configuration](../configuration.md) guide.
 
 ### Azure SQL database
 
-Update the `appsettings.json` file:
+Set the database type to `SqlServer` and provide a [connection string](https://learn.microsoft.com/ef/core/miscellaneous/connection-strings):
 
 ```json
 {
@@ -37,24 +40,32 @@ Update the `appsettings.json` file:
 
 ### Azure Blob Storage
 
-Update the `appsettings.json` file:
+Set the storage type to `AzureBlobStorage` and provide a container name to use and credentials:
 
+<Tabs groupId="blob-storage">
+<TabItem value="accessKey" label="Access Key" default>
+
+To use account name and access key, add them like this:
 ```json
 {
     ...
 
     "Storage": {
         "Type": "AzureBlobStorage",
+        "Container": "my-container",
         "AccountName": "my-account",
-        "AccessKey": "abcd1234",
-        "Container": "my-container"
+        "AccessKey": "abcd1234"
     },
 
     ...
 }
 ```
 
-Alternatively, you can use a full Azure Storage connection string:
+</TabItem>
+
+<TabItem value="connectionString" label="Connection string">
+
+To use a connection string, add it like this:
 
 ```json
 {
@@ -62,24 +73,27 @@ Alternatively, you can use a full Azure Storage connection string:
 
     "Storage": {
         "Type": "AzureBlobStorage",
-        "ConnectionString": "AccountName=my-account;AccountKey=abcd1234;...",
-        "Container": "my-container"
+        "Container": "my-container",
+        "ConnectionString": "AccountName=my-account;AccountKey=abcd1234;..."
     },
 
     ...
 }
 ```
+
+</TabItem>
+</Tabs>
 
 ### Azure Search
 
-Update the `appsettings.json` file:
+Azure Search is currently not available due to significant API changes BaGetter has to make. Once it's available, you can set the search type to `AzureSearch` and provide an account name and API key:
 
 ```json
 {
     ...
 
     "Search": {
-        "Type": "Azure",
+        "Type": "AzureSearch",
         "AccountName": "my-account",
         "ApiKey": "ABCD1234"
     },
@@ -116,8 +130,8 @@ You can restore packages by using the following package source:
 
 Some helpful guides:
 
-- [Visual Studio](https://docs.microsoft.com/en-us/nuget/consume-packages/install-use-packages-visual-studio#package-sources)
-- [NuGet.config](https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file#package-source-sections)
+- [Visual Studio](https://docs.microsoft.com/nuget/consume-packages/install-use-packages-visual-studio#package-sources)
+- [NuGet.config](https://docs.microsoft.com/nuget/reference/nuget-config-file#package-source-sections)
 
 ## Symbol server
 
@@ -125,4 +139,4 @@ You can load symbols by using the following symbol location:
 
 `http://localhost:5000/api/download/symbols`
 
-For Visual Studio, please refer to the [Configure Debugging](https://docs.microsoft.com/en-us/visualstudio/debugger/specify-symbol-dot-pdb-and-source-files-in-the-visual-studio-debugger?view=vs-2017#configure-symbol-locations-and-loading-options) guide.
+For Visual Studio, please refer to the [Configure Debugging](https://docs.microsoft.com/visualstudio/debugger/specify-symbol-dot-pdb-and-source-files-in-the-visual-studio-debugger?view=vs-2017#configure-symbol-locations-and-loading-options) guide.

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -42,7 +42,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/bagetter/BaGetter/tree/main/',
+            'https://github.com/bagetter/BaGetter/tree/main/docs',
         },
         theme: {
           customCss: './src/css/custom.css',

--- a/src/BaGetter.Azure/BaGetter.Azure.csproj
+++ b/src/BaGetter.Azure/BaGetter.Azure.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Search.Documents" />
     <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Azure.Storage.Common" />
     <PackageReference Include="Microsoft.Azure.Cosmos" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
@@ -19,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="**/*.cs" />
+    <Compile Remove="Search/*.cs" />
+    <Compile Remove="Table/*.cs" />
   </ItemGroup>
 </Project>

--- a/src/BaGetter.Azure/Configuration/AzureBlobStorageOptions.cs
+++ b/src/BaGetter.Azure/Configuration/AzureBlobStorageOptions.cs
@@ -5,7 +5,7 @@ namespace BaGetter.Azure
 {
     /// <summary>
     /// BaGetter's configurations to use Azure Blob Storage to store packages.
-    /// See: https://loic-sharma.github.io/BaGet/quickstart/azure/#azure-blob-storage
+    /// See: https://www.bagetter.com/docs/Installation/azure#azure-blob-storage
     /// </summary>
     public class AzureBlobStorageOptions : IValidatableObject
     {

--- a/src/BaGetter.Azure/Extensions/StorageExceptionExtensions.cs
+++ b/src/BaGetter.Azure/Extensions/StorageExceptionExtensions.cs
@@ -1,30 +1,29 @@
+using Azure;
 using System.Net;
 
 namespace BaGetter.Azure
 {
-    using StorageException = Microsoft.WindowsAzure.Storage.StorageException;
-    using TableStorageException = Microsoft.Azure.Cosmos.Table.StorageException;
 
     internal static class StorageExceptionExtensions
     {
-        public static bool IsAlreadyExistsException(this StorageException e)
+        public static bool IsAlreadyExistsException(this RequestFailedException e)
         {
-            return e?.RequestInformation?.HttpStatusCode == (int?)HttpStatusCode.Conflict;
+            return e?.Status == (int?)HttpStatusCode.Conflict;
         }
 
-        public static bool IsNotFoundException(this TableStorageException e)
-        {
-            return e?.RequestInformation?.HttpStatusCode == (int?)HttpStatusCode.NotFound;
-        }
+        //public static bool IsNotFoundException(this TableStorageException e)
+        //{
+        //    return e?.RequestInformation?.HttpStatusCode == (int?)HttpStatusCode.NotFound;
+        //}
 
-        public static bool IsAlreadyExistsException(this TableStorageException e)
-        {
-            return e?.RequestInformation?.HttpStatusCode == (int?)HttpStatusCode.Conflict;
-        }
+        //public static bool IsAlreadyExistsException(this TableStorageException e)
+        //{
+        //    return e?.RequestInformation?.HttpStatusCode == (int?)HttpStatusCode.Conflict;
+        //}
 
-        public static bool IsPreconditionFailedException(this TableStorageException e)
-        {
-            return e?.RequestInformation?.HttpStatusCode == (int?)HttpStatusCode.PreconditionFailed;
-        }
+        //public static bool IsPreconditionFailedException(this TableStorageException e)
+        //{
+        //    return e?.RequestInformation?.HttpStatusCode == (int?)HttpStatusCode.PreconditionFailed;
+        //}
     }
 }

--- a/src/BaGetter.Azure/Storage/BlobStorageService.cs
+++ b/src/BaGetter.Azure/Storage/BlobStorageService.cs
@@ -2,43 +2,40 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
 using BaGetter.Core;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Blob;
 
 namespace BaGetter.Azure
 {
     // See: https://github.com/NuGet/NuGetGallery/blob/master/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
     public class BlobStorageService : IStorageService
     {
-        private readonly CloudBlobContainer _container;
+        private readonly BlobContainerClient _container;
 
-        public BlobStorageService(CloudBlobContainer container)
+        public BlobStorageService(BlobContainerClient container)
         {
-            _container = container ?? throw new ArgumentNullException(nameof(container));
+            ArgumentNullException.ThrowIfNull(container);
+
+            _container = container;
         }
 
         public async Task<Stream> GetAsync(string path, CancellationToken cancellationToken)
         {
+            ArgumentException.ThrowIfNullOrEmpty(path);
+
             return await _container
-                .GetBlockBlobReference(path)
-                .OpenReadAsync(cancellationToken);
+                .GetBlobClient(path)
+                .OpenReadAsync(new(true), cancellationToken);
         }
 
         public Task<Uri> GetDownloadUriAsync(string path, CancellationToken cancellationToken)
         {
             // TODO: Make expiry time configurable.
-            var blob = _container.GetBlockBlobReference(path);
-            var accessPolicy = new SharedAccessBlobPolicy
-            {
-                SharedAccessExpiryTime = DateTimeOffset.Now.Add(TimeSpan.FromMinutes(10)),
-                Permissions = SharedAccessBlobPermissions.Read
-            };
-
-            var signature = blob.GetSharedAccessSignature(accessPolicy);
-            var result = new Uri(blob.Uri, signature);
-
-            return Task.FromResult(result);
+            var blob = _container.GetBlobClient(path);
+            return Task.FromResult(blob.GenerateSasUri(BlobSasPermissions.Read, DateTimeOffset.Now.AddMinutes(10)));
         }
 
         public async Task<StoragePutResult> PutAsync(
@@ -47,39 +44,44 @@ namespace BaGetter.Azure
             string contentType,
             CancellationToken cancellationToken)
         {
-            var blob = _container.GetBlockBlobReference(path);
-            var condition = AccessCondition.GenerateIfNotExistsCondition();
-
-            blob.Properties.ContentType = contentType;
+            var blob = _container.GetBlobClient(path);
+            var condition = new BlobRequestConditions()
+            {
+                IfNoneMatch = new ETag("*")
+            };
 
             try
             {
-                await blob.UploadFromStreamAsync(
+                await blob.UploadAsync(
                     content,
-                    condition,
-                    options: null,
-                    operationContext: null,
-                    cancellationToken: cancellationToken);
+                    new BlobUploadOptions
+                    {
+                        Conditions = condition,
+                    },
+                    cancellationToken);
+
+                await blob.SetHttpHeadersAsync(new BlobHttpHeaders
+                {
+                    ContentType = contentType,
+                }, cancellationToken: cancellationToken);
 
                 return StoragePutResult.Success;
             }
-            catch (StorageException e) when (e.IsAlreadyExistsException())
+            catch (RequestFailedException e) when (e.IsAlreadyExistsException())
             {
-                using (var targetStream = await blob.OpenReadAsync(cancellationToken))
-                {
-                    content.Position = 0;
-                    return content.Matches(targetStream)
-                        ? StoragePutResult.AlreadyExists
-                        : StoragePutResult.Conflict;
-                }
+                await using var targetStream = await blob.OpenReadAsync(new(true), cancellationToken);
+                content.Position = 0;
+                return content.Matches(targetStream)
+                    ? StoragePutResult.AlreadyExists
+                    : StoragePutResult.Conflict;
             }
         }
 
         public async Task DeleteAsync(string path, CancellationToken cancellationToken)
         {
             await _container
-                .GetBlockBlobReference(path)
-                .DeleteIfExistsAsync(cancellationToken);
+                .GetBlobClient(path)
+                .DeleteIfExistsAsync(cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/BaGetter/Startup.cs
+++ b/src/BaGetter/Startup.cs
@@ -62,7 +62,7 @@ public class Startup
         app.AddFileStorage();
         app.AddAliyunOssStorage();
         app.AddAwsS3Storage();
-        //app.AddAzureBlobStorage();
+        app.AddAzureBlobStorage();
         app.AddGoogleCloudStorage();
 
         // Add search providers.


### PR DESCRIPTION
This adds the new API of Azure Blob Storage as storage provider. Other azure providers remain deactivated as they have to be migrated to the new APIs too. 

Tested with both AccessKey and ConnectionString configurations.

Addresses #127.