### PR TITLE
Add and Endpoint option to be able to set ServiceURL

### DIFF
--- a/src/BaGetter.Aws/AwsApplicationExtensions.cs
+++ b/src/BaGetter.Aws/AwsApplicationExtensions.cs
@@ -31,10 +31,9 @@ public static class AwsApplicationExtensions
         {
             var options = provider.GetRequiredService<IOptions<S3StorageOptions>>().Value;
 
-            var config = new AmazonS3Config
-            {
-                RegionEndpoint = RegionEndpoint.GetBySystemName(options.Region)
-            };
+            var config = options.Endpoint != null
+                ? new AmazonS3Config { ServiceURL = options.Endpoint.AbsoluteUri }
+                : new AmazonS3Config { RegionEndpoint = RegionEndpoint.GetBySystemName(options.Region) };
 
             if (options.UseInstanceProfile)
             {

--- a/src/BaGetter.Aws/S3StorageOptions.cs
+++ b/src/BaGetter.Aws/S3StorageOptions.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using BaGetter.Core;
 
 namespace BaGetter.Aws;
 
-public class S3StorageOptions
+public class S3StorageOptions : IValidatableObject
 {
     [RequiredIf(nameof(SecretKey), null, IsInverted = true)]
     public string AccessKey { get; set; }
@@ -12,17 +13,35 @@ public class S3StorageOptions
     [RequiredIf(nameof(AccessKey), null, IsInverted = true)]
     public string SecretKey { get; set; }
 
-    [Required]
+    [RequiredIf(nameof(Endpoint), null)]
     public string Region { get; set; }
+
+    [RequiredIf(nameof(Region), null)]
+    public Uri Endpoint { get; set; }
 
     [Required]
     public string Bucket { get; set; }
 
     public string Prefix { get; set; }
 
-    public Uri Endpoint { get; set; }
-
     public bool UseInstanceProfile { get; set; }
 
     public string AssumeRoleArn { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (Endpoint != null && !string.IsNullOrEmpty(Region))
+        {
+            yield return new ValidationResult(
+                $"Only one of S3 {nameof(Region)} or {nameof(Endpoint)} configuration can be set, but not both.",
+                new[] { nameof(Region), nameof(Endpoint) });
+        }
+
+        if(Endpoint != null && !Endpoint.IsAbsoluteUri)
+        {
+            yield return new ValidationResult(
+                $"The S3 {nameof(Endpoint)} must be an absolute URI.",
+                new[] { nameof(Endpoint) });
+        }
+    }
 }

--- a/src/BaGetter.Aws/S3StorageOptions.cs
+++ b/src/BaGetter.Aws/S3StorageOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 using BaGetter.Core;
 
@@ -18,6 +19,8 @@ public class S3StorageOptions
     public string Bucket { get; set; }
 
     public string Prefix { get; set; }
+
+    public Uri Endpoint { get; set; }
 
     public bool UseInstanceProfile { get; set; }
 


### PR DESCRIPTION
To be able to use S3 buckets not in AWS, for example Linode, allow the option to set the Service URL in settings.

Example appsettings to configure:

```json
  "Storage": {
    "Type": "AwsS3",
    "Endpoint": "https://eu-central-1.linodeobjects.com",
    "Bucket": "testbucket",
    "AccessKey": "***",
    "SecretKey": "***"
  },
```
or 
```json
  "Storage": {
    "Type": "AwsS3",
    "Region": "eu-central-1",
    "Bucket": "testbucket",
    "AccessKey": "***",
    "SecretKey": "***"
  },
```

RegionEndpoint and ServiceUrl are mutually exclusive