### PR TITLE
Set id to lower invariant when querying Azure Table.

### DIFF
--- a/src/BaGetter.Azure/Table/TablePackageDatabase.cs
+++ b/src/BaGetter.Azure/Table/TablePackageDatabase.cs
@@ -158,7 +158,7 @@ namespace BaGetter.Azure
             bool includeUnlisted,
             CancellationToken cancellationToken)
         {
-            var result = await _table.GetEntityIfExistsAsync<PackageEntity>(id, version.ToNormalizedString(), cancellationToken: cancellationToken);
+            var result = await _table.GetEntityIfExistsAsync<PackageEntity>(id.ToLowerInvariant(), version.ToNormalizedString(), cancellationToken: cancellationToken);
 
             if (!result.HasValue)
             {


### PR DESCRIPTION
Summary of the changes (in less than 80 chars)

 * Set id to lower invariant when querying Azure Table.

Addresses #159 
