### PR TITLE
fix: Allow package repository urls to be http.

### DIFF
--- a/src/BaGetter.Core/Extensions/PackageArchiveReaderExtensions.cs
+++ b/src/BaGetter.Core/Extensions/PackageArchiveReaderExtensions.cs
@@ -159,7 +159,7 @@ public static class PackageArchiveReaderExtensions
             return (null, null);
         }
 
-        if (repositoryUri.Scheme != Uri.UriSchemeHttps)
+        if (repositoryUri.Scheme != Uri.UriSchemeHttps && repositoryUri.Scheme != Uri.UriSchemeHttp)
         {
             return (null, null);
         }


### PR DESCRIPTION
Allow package repository urls to be http as discussed in https://github.com/bagetter/BaGetter/issues/151.
