### PR TITLE
Introduce option to enable HTTP logging

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -229,7 +229,7 @@ This can be useful if you are hosting a private feed and need to host large pack
 ## Statistics
 
 On the application's statistics page the currently used services and overall package and version counts are listed.
-You can hide or show this page by modifying the `EnableStatisticsPage` configuration.  
+You can hide or show this page by modifying the `EnableStatisticsPage` configuration.
 If you set `ListConfiguredServices` to `false` the currently used services for database and storage (such as `Sqlite`) are omitted on the stats page:
 
 ```json
@@ -280,6 +280,13 @@ services:
 The specified file `./secrets/api-key.txt` contains the clear text api key only.
 
 The port mapping will make available the service at `http://localhost:5000`. (To make it available using `https` you should use an additional reverse proxy service, like "apache" or "nginx".)
+
+To enable HTTP protocol on the docker Console you can add the following variable:
+
+```yaml
+environment:
+ - Logging__Console__LogLevel__Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware=Information
+```
 
 Instead of targeting the `latest` version you may also refer to tags for major, minor and fixed releases, e.g. `1`, `1.4` or `1.4.8`.
 

--- a/src/BaGetter/Startup.cs
+++ b/src/BaGetter/Startup.cs
@@ -4,6 +4,7 @@ using BaGetter.Core.Extensions;
 using BaGetter.Web;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,6 +25,18 @@ public class Startup
 
     public void ConfigureServices(IServiceCollection services)
     {
+        // configure logging of HTTP requests
+        services.AddHttpLogging(logging =>
+        {
+            logging.LoggingFields = HttpLoggingFields.RequestPath |
+                                    HttpLoggingFields.RequestQuery |
+                                    HttpLoggingFields.RequestMethod |
+                                    HttpLoggingFields.ResponseStatusCode;
+            logging.CombineLogs = true;
+            logging.RequestHeaders.Clear();
+            logging.ResponseHeaders.Clear();
+        });
+
         services.ConfigureOptions<ValidateBaGetterOptions>();
         services.ConfigureOptions<ConfigureBaGetterServer>();
 
@@ -76,6 +89,11 @@ public class Startup
             app.UseDeveloperExceptionPage();
             app.UseStatusCodePages();
         }
+
+        // activate HTTP logging option
+        // The default severity on the Console is currently "Warning".
+        // So, the logging is not visible by default but can be easily activated using environment variable.
+        app.UseHttpLogging();
 
         app.UseForwardedHeaders();
         app.UsePathBase(options.PathBase);

--- a/src/BaGetter/appsettings.json
+++ b/src/BaGetter/appsettings.json
@@ -47,6 +47,10 @@
       "LogLevel": {
         "Microsoft.Hosting.Lifetime": "Information",
         "Default": "Warning"
+      },
+      "FormatterName": "simple",
+      "FormatterOptions": {
+        "SingleLine": true
       }
     }
   },


### PR DESCRIPTION
Allow enabling HTTP logging using docker environment variable

* Add UseHttpLogging and configure minimal logging content.
* Please note, the default logging severity remains at "Warning" which should not change the current output.
* Explicit configure "simple" logging with option "SingleLine" to get better overview in docker logs.
* Add description how to enable HTTP logging by setting LogLevel to "Information".
