### PR TITLE
Take it graceful if the icon file cannot be found

### DIFF
--- a/src/BaGetter.Core/Indexing/PackageIndexingService.cs
+++ b/src/BaGetter.Core/Indexing/PackageIndexingService.cs
@@ -62,8 +62,16 @@ public class PackageIndexingService : IPackageIndexingService
 
             if (package.HasEmbeddedIcon)
             {
-                iconStream = await packageReader.GetIconAsync(cancellationToken);
-                iconStream = await iconStream.AsTemporaryFileStreamAsync(cancellationToken);
+                try
+                {
+                    iconStream = await packageReader.GetIconAsync(cancellationToken);
+                    iconStream = await iconStream.AsTemporaryFileStreamAsync(cancellationToken);
+                }
+                catch (FileNotFoundException)
+                {
+                    // take it graceful
+                    iconStream = null;
+                }
             }
             else
             {


### PR DESCRIPTION
In case the icon cannot be found we should not get a fatal error in the logging.

Addresses #174
