### PR TITLE
New MaxVersionsPerPackage to clean packages

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -154,6 +154,20 @@ downloaded if you know the package's id and version. You can override this behav
 }
 ```
 
+## Enable package auto-deletion
+
+If your build server generates many nuget packages, your BaGet server can quickly run out of space. To avoid this issue, `MaxVersionsPerPackage` can be configured to auto-delete packages older packages when a new one is uploaded. This will use the `HardDelete` option detailed above and will unlist and delete the files for the older packages. By default this value is not configured and no packages will be deleted automatically.
+
+```json
+{
+    ...
+
+    "MaxVersionsPerPackage ": 5,
+
+    ...
+}
+```
+
 ## Enable package overwrites
 
 Normally, BaGetter will reject a package upload if the id and version are already taken. This is to maintain the [immutability of semantically versioned packages](https://learn.microsoft.com/azure/devops/artifacts/artifacts-key-concepts?view=azure-devops#immutability).

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "8.0.401",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/src/BaGetter.Core/Configuration/BaGetterOptions.cs
+++ b/src/BaGetter.Core/Configuration/BaGetterOptions.cs
@@ -47,6 +47,12 @@ public class BaGetterOptions
     /// </summary>
     public uint MaxPackageSizeGiB { get; set; } = 8;
 
+    /// <summary>
+    /// If this is set to a value, it will limit the number of versions that can be pushed for a package.
+    /// the older versions will be deleted.
+    /// </summary>
+    public uint? MaxVersionsPerPackage { get; set; } = null;
+
     public DatabaseOptions Database { get; set; }
 
     public StorageOptions Storage { get; set; }

--- a/src/BaGetter.Core/Indexing/IPackageDeletionService.cs
+++ b/src/BaGetter.Core/Indexing/IPackageDeletionService.cs
@@ -7,6 +7,15 @@ namespace BaGetter.Core;
 public interface IPackageDeletionService
 {
     /// <summary>
+    /// Delete old versions of packages
+    /// </summary>
+    /// <param name="package">Current package object to clean</param>
+    /// <param name="maxPackagesToKeep">Maximum number of packages to keep</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Number of packages deleted</returns>
+    Task<int> DeleteOldVersionsAsync(Package package, uint maxPackagesToKeep, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Attempt to delete a package.
     /// </summary>
     /// <param name="id">The id of the package to delete.</param>

--- a/src/BaGetter.Core/Indexing/PackageDeletionService.cs
+++ b/src/BaGetter.Core/Indexing/PackageDeletionService.cs
@@ -94,15 +94,16 @@ public class PackageDeletionService : IPackageDeletionService
     {
         // list all versions of the package
         var versions = await _packages.FindAsync(package.Id, includeUnlisted: true, cancellationToken);
+        if (versions is null || versions.Count <= maxPackages) return 0;
         // sort by version and take everything except the last maxPackages
         var versionsToDelete = versions
             .OrderByDescending(p => p.Version)
             .Skip((int)maxPackages)
             .ToList();
         var deleted = 0;
-        foreach (var version in versions)
+        foreach (var version in versionsToDelete)
         {
-            if (await TryDeletePackageAsync(package.Id, version.Version, cancellationToken)) deleted++;
+            if (await TryHardDeletePackageAsync(package.Id, version.Version, cancellationToken)) deleted++;
         }
         return deleted;
     }

--- a/src/BaGetter.Core/Indexing/PackageDeletionService.cs
+++ b/src/BaGetter.Core/Indexing/PackageDeletionService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -87,5 +88,22 @@ public class PackageDeletionService : IPackageDeletionService
             version);
 
         return found;
+    }
+
+    public async Task<int> DeleteOldVersionsAsync(Package package, uint maxPackages, CancellationToken cancellationToken)
+    {
+        // list all versions of the package
+        var versions = await _packages.FindAsync(package.Id, includeUnlisted: true, cancellationToken);
+        // sort by version and take everything except the last maxPackages
+        var versionsToDelete = versions
+            .OrderByDescending(p => p.Version)
+            .Skip((int)maxPackages)
+            .ToList();
+        var deleted = 0;
+        foreach (var version in versions)
+        {
+            if (await TryDeletePackageAsync(package.Id, version.Version, cancellationToken)) deleted++;
+        }
+        return deleted;
     }
 }

--- a/src/BaGetter.Core/Indexing/PackageIndexingService.cs
+++ b/src/BaGetter.Core/Indexing/PackageIndexingService.cs
@@ -164,11 +164,14 @@ public class PackageIndexingService : IPackageIndexingService
                     package.Id,
                     package.NormalizedVersionString);
                 var deleted = await _packageDeletionService.DeleteOldVersionsAsync(package, _options.Value.MaxVersionsPerPackage.Value, cancellationToken);
-                _logger.LogInformation(
-                    "Deleted {packages} older packages for package {PackageId} {PackageVersion}",
-                    deleted,
-                    package.Id,
-                    package.NormalizedVersionString);
+                if (deleted > 0)
+                {
+                    _logger.LogInformation(
+                        "Deleted {packages} older packages for package {PackageId} {PackageVersion}",
+                        deleted,
+                        package.Id,
+                        package.NormalizedVersionString);
+                }
             }
             catch (Exception e)
             {

--- a/src/BaGetter.Core/Indexing/PackageIndexingService.cs
+++ b/src/BaGetter.Core/Indexing/PackageIndexingService.cs
@@ -16,10 +16,12 @@ public class PackageIndexingService : IPackageIndexingService
     private readonly SystemTime _time;
     private readonly IOptionsSnapshot<BaGetterOptions> _options;
     private readonly ILogger<PackageIndexingService> _logger;
+    private readonly IPackageDeletionService _packageDeletionService;
 
     public PackageIndexingService(
         IPackageDatabase packages,
         IPackageStorageService storage,
+        IPackageDeletionService packageDeletionService,
         ISearchIndexer search,
         SystemTime time,
         IOptionsSnapshot<BaGetterOptions> options,
@@ -31,6 +33,7 @@ public class PackageIndexingService : IPackageIndexingService
         _time = time ?? throw new ArgumentNullException(nameof(time));
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _packageDeletionService = packageDeletionService ?? throw new ArgumentNullException(nameof(packageDeletionService));
     }
 
     public async Task<PackageIndexingResult> IndexAsync(Stream packageStream, CancellationToken cancellationToken)
@@ -152,6 +155,30 @@ public class PackageIndexingService : IPackageIndexingService
             package.NormalizedVersionString);
 
         await _search.IndexAsync(package, cancellationToken);
+
+        if (_options.Value.MaxVersionsPerPackage.HasValue)
+        {
+            try { 
+                _logger.LogInformation(
+                    "Deleting older packages for package {PackageId} {PackageVersion}",
+                    package.Id,
+                    package.NormalizedVersionString);
+                var deleted = await _packageDeletionService.DeleteOldVersionsAsync(package, _options.Value.MaxVersionsPerPackage.Value, cancellationToken);
+                _logger.LogInformation(
+                    "Deleted {packages} older packages for package {PackageId} {PackageVersion}",
+                    deleted,
+                    package.Id,
+                    package.NormalizedVersionString);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(
+                    e,
+                    "Failed to cleanup older versions of package {PackageId} {PackageVersion}",
+                    package.Id,
+                    package.NormalizedVersionString);
+            }
+        }
 
         _logger.LogInformation(
             "Successfully indexed package {Id} {Version} in search",

--- a/tests/BaGetter.Core.Tests/Services/PackageIndexingServiceInMemoryTests.cs
+++ b/tests/BaGetter.Core.Tests/Services/PackageIndexingServiceInMemoryTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using BaGetter.Core.Tests.Support;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -10,31 +11,42 @@ using Xunit;
 
 namespace BaGetter.Core.Tests.Services;
 
-public class PackageIndexingServiceTests
+/// <summary>
+/// These tests are similar to the ones in <see cref="PackageIndexingServiceTests"/>, but they use an in-memory package database.
+/// </summary>
+public class PackageIndexingServiceInMemoryTests
 {
-    private readonly Mock<IPackageDatabase> _packages;
+    private readonly IPackageDatabase _packages;
     private readonly Mock<IPackageStorageService> _storage;
     private readonly Mock<ISearchIndexer> _search;
+    private readonly IPackageDeletionService _deleter;
     private readonly Mock<SystemTime> _time;
-    private readonly Mock<IPackageDeletionService> _deleter;
     private readonly PackageIndexingService _target;
-    private readonly BaGetterOptions _mockOptions;
+    private readonly BaGetterOptions _options;
 
-    public PackageIndexingServiceTests()
+    public PackageIndexingServiceInMemoryTests()
     {
-        _packages = new Mock<IPackageDatabase>(MockBehavior.Strict);
+        _packages = new InMemoryPackageDatabase();
         _storage = new Mock<IPackageStorageService>(MockBehavior.Strict);
         _search = new Mock<ISearchIndexer>(MockBehavior.Strict);
+        _options = new();
+
+        var optionsSnapshot = new Mock<IOptionsSnapshot<BaGetterOptions>>();
+        optionsSnapshot.Setup(o => o.Value).Returns(_options);
+
+        _deleter = new PackageDeletionService(
+            _packages,
+            _storage.Object,
+            optionsSnapshot.Object,
+            Mock.Of<ILogger<PackageDeletionService>>());
         _time = new Mock<SystemTime>(MockBehavior.Loose);
-        _deleter = new Mock<IPackageDeletionService>(MockBehavior.Strict);
-        _mockOptions = new();
         var options = new Mock<IOptionsSnapshot<BaGetterOptions>>(MockBehavior.Strict);
-        options.Setup(o => o.Value).Returns(_mockOptions);
+        options.Setup(o => o.Value).Returns(_options);
 
         _target = new PackageIndexingService(
-            _packages.Object,
+            _packages,
             _storage.Object,
-            _deleter.Object,
+            _deleter,
             _search.Object,
             _time.Object,
             options.Object,
@@ -44,10 +56,10 @@ public class PackageIndexingServiceTests
     // TODO: Add malformed package tests
 
     [Fact]
-    public async Task IndexAsync_WhenPackageAlreadyExists_AndOverwriteForbidden_ReturnsPackageAlreadyExists()
+    public async Task IndexIMAsync_WhenPackageAlreadyExists_AndOverwriteForbidden_ReturnsPackageAlreadyExists()
     {
         // Arrange
-        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.False;
+        _options.AllowPackageOverwrites = PackageOverwriteAllowed.False;
 
         var builder = new PackageBuilder
         {
@@ -64,20 +76,30 @@ public class PackageIndexingServiceTests
         });
         var stream = new MemoryStream();
         builder.Save(stream);
-        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
+        _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
+        _search.Setup(s => s.IndexAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), default)).Returns(Task.CompletedTask);
 
         // Act
         var result = await _target.IndexAsync(stream, default);
 
+        var stream2 = new MemoryStream();
+        builder.Save(stream);
+
+        Assert.Equal(PackageIndexingResult.Success, result);
+
+        // Act
+        var result2 = await _target.IndexAsync(stream, default);
+
         // Assert
-        Assert.Equal(PackageIndexingResult.PackageAlreadyExists, result);
+        Assert.Equal(PackageIndexingResult.PackageAlreadyExists, result2);
+
     }
 
     [Fact]
-    public async Task IndexAsync_WhenPackageAlreadyExists_AndOverwriteAllowed_IndexesPackage()
+    public async Task IndexIMAsync_WhenPackageAlreadyExists_AndOverwriteAllowed_IndexesPackage()
     {
         // Arrange
-        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.True;
+        _options.AllowPackageOverwrites = PackageOverwriteAllowed.True;
 
         var builder = new PackageBuilder
         {
@@ -94,9 +116,6 @@ public class PackageIndexingServiceTests
         });
         var stream = new MemoryStream();
         builder.Save(stream);
-        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
-        _packages.Setup(p => p.HardDeletePackageAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
-        _packages.Setup(p => p.AddAsync(It.Is<Package>(p1 => p1.Id == builder.Id && p1.Version.ToString() == builder.Version.ToString()), default)).ReturnsAsync(PackageAddResult.Success);
 
         _storage.Setup(s => s.DeleteAsync(builder.Id, builder.Version, default)).Returns(Task.CompletedTask);
         _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
@@ -111,10 +130,10 @@ public class PackageIndexingServiceTests
     }
 
     [Fact]
-    public async Task IndexAsync_WhenPrereleasePackageAlreadyExists_AndOverwritePrereleaseAllowed_IndexesPackage()
+    public async Task IndexIMAsync_WhenPrereleasePackageAlreadyExists_AndOverwritePrereleaseAllowed_IndexesPackage()
     {
         // Arrange
-        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.PrereleaseOnly;
+        _options.AllowPackageOverwrites = PackageOverwriteAllowed.PrereleaseOnly;
 
         var builder = new PackageBuilder
         {
@@ -131,9 +150,6 @@ public class PackageIndexingServiceTests
         });
         var stream = new MemoryStream();
         builder.Save(stream);
-        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
-        _packages.Setup(p => p.HardDeletePackageAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
-        _packages.Setup(p => p.AddAsync(It.Is<Package>(p1 => p1.Id == builder.Id && p1.Version.ToString() == builder.Version.ToString()), default)).ReturnsAsync(PackageAddResult.Success);
 
         _storage.Setup(s => s.DeleteAsync(builder.Id, builder.Version, default)).Returns(Task.CompletedTask);
         _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
@@ -148,10 +164,10 @@ public class PackageIndexingServiceTests
     }
 
     [Fact]
-    public async Task IndexAsync_WhenPrereleasePackageAlreadyExists_AndOverwriteForbidden_ReturnsPackageAlreadyExists()
+    public async Task IndexIMAsync_WhenPrereleasePackageAlreadyExists_AndOverwriteForbidden_ReturnsPackageAlreadyExists()
     {
         // Arrange
-        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.False;
+        _options.AllowPackageOverwrites = PackageOverwriteAllowed.False;
 
         var builder = new PackageBuilder
         {
@@ -168,20 +184,32 @@ public class PackageIndexingServiceTests
         });
         var stream = new MemoryStream();
         builder.Save(stream);
-        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
+
+        _storage.Setup(s => s.DeleteAsync(builder.Id, builder.Version, default)).Returns(Task.CompletedTask);
+        _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
+
+        _search.Setup(s => s.IndexAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), default)).Returns(Task.CompletedTask);
 
         // Act
         var result = await _target.IndexAsync(stream, default);
 
+        var stream2 = new MemoryStream();
+        builder.Save(stream);
+
+        Assert.Equal(PackageIndexingResult.Success, result);
+
+        // Act
+        var result2 = await _target.IndexAsync(stream, default);
+
         // Assert
-        Assert.Equal(PackageIndexingResult.PackageAlreadyExists, result);
+        Assert.Equal(PackageIndexingResult.PackageAlreadyExists, result2);
     }
 
     [Fact]
-    public async Task IndexAsync_WithValidPackage_ReturnsSuccess()
+    public async Task IndexIMAsync_WithValidPackage_ReturnsSuccess()
     {
         // Arrange
-        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.False;
+        _options.AllowPackageOverwrites = PackageOverwriteAllowed.False;
         var builder = new PackageBuilder
         {
             Id = "bagetter-test",
@@ -197,8 +225,6 @@ public class PackageIndexingServiceTests
         });
         var stream = new MemoryStream();
         builder.Save(stream);
-        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(false);
-        _packages.Setup(p => p.AddAsync(It.Is<Package>(p1 => p1.Id == builder.Id && p1.Version.ToString() == builder.Version.ToString()), default)).ReturnsAsync(PackageAddResult.Success);
 
         _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
 
@@ -212,14 +238,52 @@ public class PackageIndexingServiceTests
     }
 
     [Fact]
-    public async Task WhenDatabaseAddFailsBecausePackageAlreadyExists_ReturnsPackageAlreadyExists()
+    public async Task IndexIMAsync_WithValidPackage_CleansOldVersions()
     {
-        await Task.Yield();
+        // Arrange
+        _options.AllowPackageOverwrites = PackageOverwriteAllowed.False;
+        _options.MaxVersionsPerPackage = 5;
+        // Add 10 packages
+        for (var i = 0; i < 10; i++)
+        {
+            var builder = new PackageBuilder
+            {
+                Id = "bagetter-test",
+                Version = NuGetVersion.Parse($"1.0.{i}"),
+                Description = "Test Description",
+            };
+            builder.Authors.Add("Test Author");
+            var assemblyFile = GetType().Assembly.Location;
+            builder.Files.Add(new PhysicalPackageFile
+            {
+                SourcePath = assemblyFile,
+                TargetPath = "lib/Test.dll"
+            });
+            var stream = new MemoryStream();
+            builder.Save(stream);
+            //_packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(false);
+            //_packages.Setup(p => p.AddAsync(It.Is<Package>(p1 => p1.Id == builder.Id && p1.Version.ToString() == builder.Version.ToString()), default)).ReturnsAsync(PackageAddResult.Success);
+
+            _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
+
+            _search.Setup(s => s.IndexAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), default)).Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _target.IndexAsync(stream, default);
+
+            // Assert
+            Assert.Equal(PackageIndexingResult.Success, result);
+
+            var packageCount = await _packages.FindAsync(builder.Id, true, default);
+            if (i < 5)
+            {
+                Assert.Equal(i + 1, packageCount.Count);
+            }
+            else
+            {
+                Assert.Equal(5, packageCount.Count);
+            }
+        }
     }
 
-    [Fact]
-    public async Task ThrowsWhenStorageSaveThrows()
-    {
-        await Task.Yield();
-    }
 }

--- a/tests/BaGetter.Core.Tests/Services/PackageIndexingServiceTests.cs
+++ b/tests/BaGetter.Core.Tests/Services/PackageIndexingServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using BaGetter.Core.Tests.Support;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -12,29 +13,37 @@ namespace BaGetter.Core.Tests.Services;
 
 public class PackageIndexingServiceTests
 {
-    private readonly Mock<IPackageDatabase> _packages;
+    private readonly IPackageDatabase _packages;
     private readonly Mock<IPackageStorageService> _storage;
     private readonly Mock<ISearchIndexer> _search;
-    private readonly Mock<IPackageDeletionService> _deleter;
+    private readonly IPackageDeletionService _deleter;
     private readonly Mock<SystemTime> _time;
     private readonly PackageIndexingService _target;
-    private readonly BaGetterOptions _mockOptions;
+    private readonly BaGetterOptions _options;
 
     public PackageIndexingServiceTests()
     {
-        _packages = new Mock<IPackageDatabase>(MockBehavior.Strict);
+        _packages = new InMemoryPackageDatabase();
         _storage = new Mock<IPackageStorageService>(MockBehavior.Strict);
         _search = new Mock<ISearchIndexer>(MockBehavior.Strict);
-        _deleter = new Mock<IPackageDeletionService>(MockBehavior.Strict);
+        _options = new();
+
+        var optionsSnapshot = new Mock<IOptionsSnapshot<BaGetterOptions>>();
+        optionsSnapshot.Setup(o => o.Value).Returns(_options);
+
+        _deleter = new PackageDeletionService(
+            _packages,
+            _storage.Object,
+            optionsSnapshot.Object,
+            Mock.Of<ILogger<PackageDeletionService>>());
         _time = new Mock<SystemTime>(MockBehavior.Loose);
-        _mockOptions = new();
         var options = new Mock<IOptionsSnapshot<BaGetterOptions>>(MockBehavior.Strict);
-        options.Setup(o => o.Value).Returns(_mockOptions);
+        options.Setup(o => o.Value).Returns(_options);
 
         _target = new PackageIndexingService(
-            _packages.Object,
+            _packages,
             _storage.Object,
-            _deleter.Object,
+            _deleter,
             _search.Object,
             _time.Object,
             options.Object,
@@ -47,7 +56,7 @@ public class PackageIndexingServiceTests
     public async Task IndexAsync_WhenPackageAlreadyExists_AndOverwriteForbidden_ReturnsPackageAlreadyExists()
     {
         // Arrange
-        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.False;
+        _options.AllowPackageOverwrites = PackageOverwriteAllowed.False;
 
         var builder = new PackageBuilder
         {
@@ -64,20 +73,30 @@ public class PackageIndexingServiceTests
         });
         var stream = new MemoryStream();
         builder.Save(stream);
-        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
+        _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
+        _search.Setup(s => s.IndexAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), default)).Returns(Task.CompletedTask);
 
         // Act
         var result = await _target.IndexAsync(stream, default);
 
+        var stream2 = new MemoryStream();
+        builder.Save(stream);
+
+        Assert.Equal(PackageIndexingResult.Success, result);
+
+        // Act
+        var result2 = await _target.IndexAsync(stream, default);
+
         // Assert
-        Assert.Equal(PackageIndexingResult.PackageAlreadyExists, result);
+        Assert.Equal(PackageIndexingResult.PackageAlreadyExists, result2);
+
     }
 
     [Fact]
     public async Task IndexAsync_WhenPackageAlreadyExists_AndOverwriteAllowed_IndexesPackage()
     {
         // Arrange
-        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.True;
+        _options.AllowPackageOverwrites = PackageOverwriteAllowed.True;
 
         var builder = new PackageBuilder
         {
@@ -94,9 +113,9 @@ public class PackageIndexingServiceTests
         });
         var stream = new MemoryStream();
         builder.Save(stream);
-        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
-        _packages.Setup(p => p.HardDeletePackageAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
-        _packages.Setup(p => p.AddAsync(It.Is<Package>(p1 => p1.Id == builder.Id && p1.Version.ToString() == builder.Version.ToString()), default)).ReturnsAsync(PackageAddResult.Success);
+        //_packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
+        //_packages.Setup(p => p.HardDeletePackageAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
+        //_packages.Setup(p => p.AddAsync(It.Is<Package>(p1 => p1.Id == builder.Id && p1.Version.ToString() == builder.Version.ToString()), default)).ReturnsAsync(PackageAddResult.Success);
 
         _storage.Setup(s => s.DeleteAsync(builder.Id, builder.Version, default)).Returns(Task.CompletedTask);
         _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
@@ -114,7 +133,7 @@ public class PackageIndexingServiceTests
     public async Task IndexAsync_WhenPrereleasePackageAlreadyExists_AndOverwritePrereleaseAllowed_IndexesPackage()
     {
         // Arrange
-        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.PrereleaseOnly;
+        _options.AllowPackageOverwrites = PackageOverwriteAllowed.PrereleaseOnly;
 
         var builder = new PackageBuilder
         {
@@ -131,9 +150,6 @@ public class PackageIndexingServiceTests
         });
         var stream = new MemoryStream();
         builder.Save(stream);
-        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
-        _packages.Setup(p => p.HardDeletePackageAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
-        _packages.Setup(p => p.AddAsync(It.Is<Package>(p1 => p1.Id == builder.Id && p1.Version.ToString() == builder.Version.ToString()), default)).ReturnsAsync(PackageAddResult.Success);
 
         _storage.Setup(s => s.DeleteAsync(builder.Id, builder.Version, default)).Returns(Task.CompletedTask);
         _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
@@ -151,7 +167,7 @@ public class PackageIndexingServiceTests
     public async Task IndexAsync_WhenPrereleasePackageAlreadyExists_AndOverwriteForbidden_ReturnsPackageAlreadyExists()
     {
         // Arrange
-        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.False;
+        _options.AllowPackageOverwrites = PackageOverwriteAllowed.False;
 
         var builder = new PackageBuilder
         {
@@ -168,20 +184,32 @@ public class PackageIndexingServiceTests
         });
         var stream = new MemoryStream();
         builder.Save(stream);
-        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(true);
+
+        _storage.Setup(s => s.DeleteAsync(builder.Id, builder.Version, default)).Returns(Task.CompletedTask);
+        _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
+
+        _search.Setup(s => s.IndexAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), default)).Returns(Task.CompletedTask);
 
         // Act
         var result = await _target.IndexAsync(stream, default);
 
+        var stream2 = new MemoryStream();
+        builder.Save(stream);
+
+        Assert.Equal(PackageIndexingResult.Success, result);
+
+        // Act
+        var result2 = await _target.IndexAsync(stream, default);
+
         // Assert
-        Assert.Equal(PackageIndexingResult.PackageAlreadyExists, result);
+        Assert.Equal(PackageIndexingResult.PackageAlreadyExists, result2);
     }
 
     [Fact]
     public async Task IndexAsync_WithValidPackage_ReturnsSuccess()
     {
         // Arrange
-        _mockOptions.AllowPackageOverwrites = PackageOverwriteAllowed.False;
+        _options.AllowPackageOverwrites = PackageOverwriteAllowed.False;
         var builder = new PackageBuilder
         {
             Id = "bagetter-test",
@@ -197,8 +225,8 @@ public class PackageIndexingServiceTests
         });
         var stream = new MemoryStream();
         builder.Save(stream);
-        _packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(false);
-        _packages.Setup(p => p.AddAsync(It.Is<Package>(p1 => p1.Id == builder.Id && p1.Version.ToString() == builder.Version.ToString()), default)).ReturnsAsync(PackageAddResult.Success);
+        //_packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(false);
+        //_packages.Setup(p => p.AddAsync(It.Is<Package>(p1 => p1.Id == builder.Id && p1.Version.ToString() == builder.Version.ToString()), default)).ReturnsAsync(PackageAddResult.Success);
 
         _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
 
@@ -210,6 +238,56 @@ public class PackageIndexingServiceTests
         // Assert
         Assert.Equal(PackageIndexingResult.Success, result);
     }
+
+    [Fact]
+    public async Task IndexAsync_WithValidPackage_CleansOldVersions()
+    {
+        // Arrange
+        _options.AllowPackageOverwrites = PackageOverwriteAllowed.False;
+        _options.MaxVersionsPerPackage = 5;
+        // Add 10 packages
+        for (var i = 0; i < 10; i++)
+        {
+            var builder = new PackageBuilder
+            {
+                Id = "bagetter-test",
+                Version = NuGetVersion.Parse($"1.0.{i}"),
+                Description = "Test Description",
+            };
+            builder.Authors.Add("Test Author");
+            var assemblyFile = GetType().Assembly.Location;
+            builder.Files.Add(new PhysicalPackageFile
+            {
+                SourcePath = assemblyFile,
+                TargetPath = "lib/Test.dll"
+            });
+            var stream = new MemoryStream();
+            builder.Save(stream);
+            //_packages.Setup(p => p.ExistsAsync(builder.Id, builder.Version, default)).ReturnsAsync(false);
+            //_packages.Setup(p => p.AddAsync(It.Is<Package>(p1 => p1.Id == builder.Id && p1.Version.ToString() == builder.Version.ToString()), default)).ReturnsAsync(PackageAddResult.Success);
+
+            _storage.Setup(s => s.SavePackageContentAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), stream, It.IsAny<FileStream>(), default, default, default)).Returns(Task.CompletedTask);
+
+            _search.Setup(s => s.IndexAsync(It.Is<Package>(p => p.Id == builder.Id && p.Version.ToString() == builder.Version.ToString()), default)).Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _target.IndexAsync(stream, default);
+
+            // Assert
+            Assert.Equal(PackageIndexingResult.Success, result);
+
+            var packageCount = await _packages.FindAsync(builder.Id, true, default);
+            if (i < 5)
+            {
+                Assert.Equal(i + 1, packageCount.Count);
+            }
+            else
+            {
+                Assert.Equal(5, packageCount.Count);
+            }
+        }
+    }
+
 
     [Fact]
     public async Task WhenDatabaseAddFailsBecausePackageAlreadyExists_ReturnsPackageAlreadyExists()

--- a/tests/BaGetter.Core.Tests/Services/PackageIndexingServiceTests.cs
+++ b/tests/BaGetter.Core.Tests/Services/PackageIndexingServiceTests.cs
@@ -15,6 +15,7 @@ public class PackageIndexingServiceTests
     private readonly Mock<IPackageDatabase> _packages;
     private readonly Mock<IPackageStorageService> _storage;
     private readonly Mock<ISearchIndexer> _search;
+    private readonly Mock<IPackageDeletionService> _deleter;
     private readonly Mock<SystemTime> _time;
     private readonly PackageIndexingService _target;
     private readonly BaGetterOptions _mockOptions;
@@ -24,6 +25,7 @@ public class PackageIndexingServiceTests
         _packages = new Mock<IPackageDatabase>(MockBehavior.Strict);
         _storage = new Mock<IPackageStorageService>(MockBehavior.Strict);
         _search = new Mock<ISearchIndexer>(MockBehavior.Strict);
+        _deleter = new Mock<IPackageDeletionService>(MockBehavior.Strict);
         _time = new Mock<SystemTime>(MockBehavior.Loose);
         _mockOptions = new();
         var options = new Mock<IOptionsSnapshot<BaGetterOptions>>(MockBehavior.Strict);
@@ -32,6 +34,7 @@ public class PackageIndexingServiceTests
         _target = new PackageIndexingService(
             _packages.Object,
             _storage.Object,
+            _deleter.Object,
             _search.Object,
             _time.Object,
             options.Object,

--- a/tests/BaGetter.Core.Tests/Support/InMemoryPackageDatabase.cs
+++ b/tests/BaGetter.Core.Tests/Support/InMemoryPackageDatabase.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Versioning;
+
+namespace BaGetter.Core.Tests.Support;
+public class InMemoryPackageDatabase : IPackageDatabase
+{
+    private readonly List<Package> _packages = new List<Package>();
+
+    public Task<PackageAddResult> AddAsync(Package package, CancellationToken cancellationToken)
+    {
+        _packages.Add(package);
+        return Task.FromResult(PackageAddResult.Success);
+    }
+
+    public Task AddDownloadAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<bool> ExistsAsync(string id, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> ExistsAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
+    {
+        var exists = _packages.Any(p => p.Id == id && p.Version == version);
+        return Task.FromResult(exists);
+    }
+
+    public Task<IReadOnlyList<Package>> FindAsync(string id, bool includeUnlisted, CancellationToken cancellationToken)
+    {
+        return Task.FromResult((IReadOnlyList<Package>)_packages.Where(p => p.Id == id).ToList().AsReadOnly());
+    }
+
+    public async Task<Package> FindOrNullAsync(string id, NuGetVersion version, bool includeUnlisted, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> HardDeletePackageAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
+    {
+        var removed = _packages.RemoveAll(p => p.Id == id && p.Version == version);
+        return Task.FromResult(removed > 0);
+    }
+
+    public async Task<bool> RelistPackageAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> UnlistPackageAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(true);
+    }
+}


### PR DESCRIPTION
Added a new optional setting `MaxVersionsPerPackage` to auto delete packages when there are more than `MaxVersionsPerPackage` versions. We have been running out of space regularly on our bagetter server and been looking for a system to auto clean.

I added corresponding unit tests, this required adding a `InMemoryPackageDatabase` implementation. All unit tests do pass.