### PR TITLE
Fix: Add XForwardedHost to ForwardedHeaders (#205)

### DIFF
--- a/src/BaGetter/ConfigureBaGetterServer.cs
+++ b/src/BaGetter/ConfigureBaGetterServer.cs
@@ -40,7 +40,7 @@ public class ConfigureBaGetterServer
 
     public void Configure(ForwardedHeadersOptions options)
     {
-        options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+        options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost;
 
         // Do not restrict to local network/proxy
         options.KnownNetworks.Clear();


### PR DESCRIPTION
## Pull Request Description

This updates the `Configure` method in `src/Bagetter/ConfigureBaGetterServier.cs` to include the missing `XForwardedHost` flag in the `ForwardedHeaders` options. This change ensures that when running behind a reverse proxy, the proper host header is used for generating URLs correctly.

**Addresses:** [#205](https://github.com/bagetter/BaGet/issues/205)
