### PR TITLE
Update docker.md - Apache 2 reverse proxy example

### DIFF
--- a/docs/docs/Installation/docker.md
+++ b/docs/docs/Installation/docker.md
@@ -99,3 +99,28 @@ For Visual Studio, please refer to the [Configure Debugging](https://docs.micros
 
 BaGetter can be run behind a reverse proxy in order to provide HTTPS, your own domain, and other features. For the API to deliver proper URLs, the proxy needs to forward the `X-Forwarded-Host` header, or the `Host` header iteslf.  
 For more information, please refer to the [ASP.NET Core documentation](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer).
+
+Consider binding port 5000 to localhost only using -p 127.0.0.1:5000:8080
+
+### Apache 2 Configuration
+```config
+<IfModule mod_ssl.c>
+	<VirtualHost *:443>
+
+		ServerName nuget.myserver.com
+
+		ProxyRequests Off
+		ProxyPreserveHost On
+		ProxyPass / http://localhost:5000/
+		ProxyPassReverse / http://localhost:5000/
+		RequestHeader set X-Forwarded-Proto https
+
+		SSLCertificateFile /etc/letsencrypt/live/nuget.myserver.com/fullchain.pem #managed by cerbot
+		SSLCertificateKeyFile /etc/letsencrypt/live/nuget.myserver.com/privkey.pem #managed by cerbot
+		Include /etc/letsencrypt/options-ssl-apache.conf
+		Header always set Strict-Transport-Security "max-age=31536000"
+		Header always set Content-Security-Policy upgrade-insecure-requests
+	</VirtualHost>
+</IfModule>
+```
+

--- a/docs/docs/Installation/docker.md
+++ b/docs/docs/Installation/docker.md
@@ -100,14 +100,14 @@ For Visual Studio, please refer to the [Configure Debugging](https://docs.micros
 BaGetter can be run behind a reverse proxy in order to provide HTTPS, your own domain, and other features. For the API to deliver proper URLs, the proxy needs to forward the `X-Forwarded-Host` header, or the `Host` header iteslf.  
 For more information, please refer to the [ASP.NET Core documentation](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer).
 
-Consider binding port 5000 to localhost only using -p 127.0.0.1:5000:8080
+Consider binding port 5000 to localhost only using -p 127.0.0.1:5000:8080 to avoid any transmission of non encrypted data even over internal networks
 
 ### Apache 2 Configuration
 ```config
 <IfModule mod_ssl.c>
 	<VirtualHost *:443>
 
-		ServerName nuget.myserver.com
+		ServerName nuget.example.com
 
 		ProxyRequests Off
 		ProxyPreserveHost On
@@ -115,8 +115,8 @@ Consider binding port 5000 to localhost only using -p 127.0.0.1:5000:8080
 		ProxyPassReverse / http://localhost:5000/
 		RequestHeader set X-Forwarded-Proto https
 
-		SSLCertificateFile /etc/letsencrypt/live/nuget.myserver.com/fullchain.pem #managed by cerbot
-		SSLCertificateKeyFile /etc/letsencrypt/live/nuget.myserver.com/privkey.pem #managed by cerbot
+		SSLCertificateFile /etc/letsencrypt/live/nuget.example.com/fullchain.pem #managed by cerbot
+		SSLCertificateKeyFile /etc/letsencrypt/live/nuget.example.com/privkey.pem #managed by cerbot
 		Include /etc/letsencrypt/options-ssl-apache.conf
 		Header always set Strict-Transport-Security "max-age=31536000"
 		Header always set Content-Security-Policy upgrade-insecure-requests


### PR DESCRIPTION
Added an example for an Apache 2 reverse proxy configuration

Summary of the changes (in less than 80 chars)

 * Added an example of an Apache 2 configuration for the reverse proxy. Added a point regarding binding the internal service to 127.0.0.1 only for security reasons


