### PR TITLE
Added ForcePathStyle Configuration Option 279

### DIFF
--- a/docs/docs/Installation/aws.md
+++ b/docs/docs/Installation/aws.md
@@ -67,10 +67,10 @@ For example:
   "Storage": {
     "Type": "AwsS3",
     "ServiceUrl": "http://localhost:9000",
+    "ForcePathStyle": true,
     "Bucket": "nuget-packages",
     "AccessKey": "minioadmin",
-    "SecretKey": "minioadmin",
-    "ForcePathStyle": true
+    "SecretKey": "minioadmin"
   }
   // ...
 }

--- a/docs/docs/Installation/aws.md
+++ b/docs/docs/Installation/aws.md
@@ -35,33 +35,50 @@ Update the `appsettings.json` file with those:
     ...
 }
 ```
-
 #### S3-compatible object storage
 
-You can use any other S3-compatible storage service, as long as it's compatible with Amazon AWS S3. Since the URL for services other than Amazon AWS will change, you need to provide this Service URL instead of the Region. For example:
+You can use any other S3-compatible storage service, as long as it's compatible with the Amazon AWS SDK S3 Client. Since the URL for services other than Amazon AWS will change, you need to provide the `ServiceUrl` instead of the `Region`. For example:
 
 ```json
 {
-    ...
-
-    "Storage": {
-        "Type": "AwsS3",
-        "Endpoint": "https://eu-central-1.linodeobjects.com",
-        "Bucket": "nuget-packages",
-        "AccessKey": "",
-        "SecretKey": ""
-    },
-
-    ...
+  // ...
+  "Storage": {
+    "Type": "AwsS3",
+    "ServiceUrl": "https://eu-central-1.linodeobjects.com",
+    "Bucket": "nuget-packages",
+    "AccessKey": "",
+    "SecretKey": ""
+  }
+  // ...
 }
 ```
 
-Note: to avoid errors, only one of `Region` or `Endpoint` setting can be set at the same time.
+> ⚠️ **Note:** To avoid errors, only one of the `Region` or `ServiceUrl` (Endpoint) settings can be configured at the same time.
+
+If your third-party S3 service (such as a local MinIO instance) does not support virtual host-style addressing, you can force the AWS SDK to use path-style addressing (where the bucket name is part of the URL path) by setting the `ForcePathStyle` option to `true`.
+
+> ⚠️ **Note:** The `ForcePathStyle` option can **only** be used when `ServiceUrl` is also configured.
+
+For example:
+
+```json
+{
+  // ...
+  "Storage": {
+    "Type": "AwsS3",
+    "ServiceUrl": "http://localhost:9000",
+    "Bucket": "nuget-packages",
+    "AccessKey": "minioadmin",
+    "SecretKey": "minioadmin",
+    "ForcePathStyle": true
+  }
+  // ...
+}
+```
 
 #### Known compatible services
 
-So far, it has been tested in [Linode’s Object Storage](https://www.linode.com/docs/products/storage/object-storage/). If you succeed in using other storage service, let us know so we can state it here.
-
+So far, it has been tested with [Linode’s Object Storage](https://www.linode.com/docs/products/storage/object-storage/) and [Local MinIO](https://github.com/minio/minio). If you succeed in using another storage service, let us know so we can list it here.
 
 ### Amazon RDS
 

--- a/src/BaGetter.Aws/AwsApplicationExtensions.cs
+++ b/src/BaGetter.Aws/AwsApplicationExtensions.cs
@@ -32,7 +32,7 @@ public static class AwsApplicationExtensions
             var options = provider.GetRequiredService<IOptions<S3StorageOptions>>().Value;
 
             var config = options.Endpoint != null
-                ? new AmazonS3Config { ServiceURL = options.Endpoint.AbsoluteUri }
+                ? new AmazonS3Config { ServiceURL = options.Endpoint.AbsoluteUri, ForcePathStyle = options.ForcePathStyle }
                 : new AmazonS3Config { RegionEndpoint = RegionEndpoint.GetBySystemName(options.Region) };
 
             if (options.UseInstanceProfile)

--- a/src/BaGetter.Aws/S3StorageOptions.cs
+++ b/src/BaGetter.Aws/S3StorageOptions.cs
@@ -19,6 +19,8 @@ public class S3StorageOptions : IValidatableObject
     [RequiredIf(nameof(Region), null)]
     public Uri Endpoint { get; set; }
 
+    public bool ForcePathStyle { get; set; }
+    
     [Required]
     public string Bucket { get; set; }
 


### PR DESCRIPTION
### Description
This PR addresses the missing capability to enforce path-style URLs when using the `AwsS3` storage type. This is crucial for local testing infrastructure (e.g., using a local MinIO server) or alternative S3 cloud vendors that do not support or require virtual-host-style addressing.

Fixes #279 

### Changes
- Extended the AWS S3 configuration schema to accept an optional `ForcePathStyle` boolean parameter.
- Mapped this configuration parameter directly onto the `AmazonS3Config` instance initialization inside `BaGetter.Aws`.
- Maintained strict backward compatibility: if the option is not provided in `appsettings.json`, the behavior remains entirely unchanged.

### Verification & Testing
- Successfully tested locally using a **MinIO S3 Server** instance acting as the backend storage provider.
- Verified that package uploads and downloads work without issues when `ForcePathStyle` is enabled.
- Verified that existing standard AWS configurations continue to work as expected.
