### PR TITLE
feat: add upstream search and full proxy mode for upstream package assets

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -157,6 +157,69 @@ The following `Mirror` setting configures BaGetter to index packages from [nuget
 
 :::
 
+## Include upstream packages in search
+
+By default, search and autocomplete return only packages already indexed by BaGetter. To include
+results from the configured mirror source in the NuGet API and web browse page, enable upstream search:
+
+```json
+{
+    ...
+
+    "Mirror": {
+        "Enabled": true,
+        "PackageSource": "https://api.nuget.org/v3/index.json"
+    },
+    "Search": {
+        "IncludeUpstream": true
+    },
+
+    ...
+}
+```
+
+This setting uses the source and authentication configured in `Mirror`. Packages are still downloaded
+and cached only when a client requests a package version.
+
+## Full proxy mode
+
+In locked-down environments where only the BaGetter server can reach the upstream feed (clients can
+reach only BaGetter), enable full proxy mode. When enabled, BaGetter rewrites upstream
+package-resource asset URLs (icon and license URLs) found in metadata and search responses to
+BaGetter URLs and fetches those assets server-side, so clients never contact the upstream directly:
+
+```json
+{
+    ...
+
+    "Mirror": {
+        "Enabled": true,
+        "PackageSource": "https://api.nuget.org/v3/index.json"
+    },
+    "FullProxy": {
+        "Enabled": true,
+        "CacheMinutes": 30,
+        "AssetCacheMinutes": 1440
+    },
+
+    ...
+}
+```
+
+Full proxy needs a configured `Mirror` source to proxy upstream assets and implies upstream search
+(no separate `Search:IncludeUpstream` is needed). The set of trusted upstream hosts is **derived at
+runtime** from the configured `Mirror` upstream (its package source and service index resources), so
+this works for any provider, not just nuget.org — no host list is configured.
+
+- `CacheMinutes` — how long upstream search/autocomplete responses are cached (0 disables).
+- `AssetCacheMinutes` — how long proxied assets are cached.
+
+Only assets hosted on the configured upstream's own infrastructure are proxied. Truly external,
+author-supplied URLs (for example an icon hosted on a third-party site) are left untouched, because
+proxying arbitrary hosts would turn BaGetter into an open proxy. The asset proxy accepts only HTTPS
+URLs on trusted upstream hosts and rejects loopback/private addresses (SSRF protection). The cache is
+in-memory and therefore per-instance.
+
 ## Enable package hard deletions
 
 To prevent the ["left pad" problem](https://blog.npmjs.org/post/141577284765/kik-left-pad-and-npm),

--- a/src/BaGetter.Core/Configuration/BaGetterOptions.cs
+++ b/src/BaGetter.Core/Configuration/BaGetterOptions.cs
@@ -68,6 +68,8 @@ public class BaGetterOptions
 
     public MirrorOptions Mirror { get; set; }
 
+    public FullProxyOptions FullProxy { get; set; }
+
     public HealthCheckOptions HealthCheck { get; set; }
 
     public StatisticsOptions Statistics { get; set; }

--- a/src/BaGetter.Core/Configuration/FullProxyOptions.cs
+++ b/src/BaGetter.Core/Configuration/FullProxyOptions.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BaGetter.Core;
+
+/// <summary>
+/// Options for "full proxy" mode. When enabled, BaGetter rewrites upstream
+/// package-resource asset URLs (icon and license URLs) found in metadata and
+/// search responses to BaGetter asset-proxy URLs and fetches those assets
+/// server-side, so clients never contact the upstream directly.
+///
+/// The set of trusted upstream hosts is derived at runtime from the configured
+/// <see cref="MirrorOptions"/> upstream (package source + service index
+/// resources), so this works for any provider without a static host list.
+/// </summary>
+public class FullProxyOptions
+{
+    /// <summary>
+    /// Whether full proxy mode is enabled. When <see langword="false"/>, behavior
+    /// is identical to BaGetter without full proxy.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// How long upstream search and autocomplete responses are cached, in minutes.
+    /// Set to 0 to disable search caching.
+    /// </summary>
+    [Range(0, int.MaxValue)]
+    public int CacheMinutes { get; set; } = 30;
+
+    /// <summary>
+    /// How long proxied upstream assets are cached, in minutes.
+    /// Set to 0 to disable asset caching.
+    /// </summary>
+    [Range(0, int.MaxValue)]
+    public int AssetCacheMinutes { get; set; } = 1440;
+}

--- a/src/BaGetter.Core/Configuration/SearchOptions.cs
+++ b/src/BaGetter.Core/Configuration/SearchOptions.cs
@@ -3,4 +3,10 @@ namespace BaGetter.Core;
 public class SearchOptions
 {
     public string Type { get; set; }
+
+    /// <summary>
+    /// Whether search and autocomplete responses should include packages from
+    /// the configured upstream mirror source.
+    /// </summary>
+    public bool IncludeUpstream { get; set; }
 }

--- a/src/BaGetter.Core/Content/DefaultPackageContentService.cs
+++ b/src/BaGetter.Core/Content/DefaultPackageContentService.cs
@@ -15,13 +15,16 @@ public class DefaultPackageContentService : IPackageContentService
 {
     private readonly IPackageService _packages;
     private readonly IPackageStorageService _storage;
+    private readonly IUpstreamClient _upstream;
 
     public DefaultPackageContentService(
         IPackageService packages,
-        IPackageStorageService storage)
+        IPackageStorageService storage,
+        IUpstreamClient upstream)
     {
         _packages = packages ?? throw new ArgumentNullException(nameof(packages));
         _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+        _upstream = upstream ?? throw new ArgumentNullException(nameof(upstream));
     }
 
     public async Task<PackageVersionsResponse> GetPackageVersionsOrNullAsync(
@@ -70,12 +73,25 @@ public class DefaultPackageContentService : IPackageContentService
     public async Task<Stream> GetPackageReadmeStreamOrNullAsync(string id, NuGetVersion version, CancellationToken cancellationToken = default)
     {
         var package = await _packages.FindPackageOrNullAsync(id, version, cancellationToken);
-        if (package == null || !package.HasReadme)
+        if (package == null)
         {
             return null;
         }
 
-        return await _storage.GetReadmeStreamAsync(id, version, cancellationToken);
+        if (!package.HasReadme)
+        {
+            return await _upstream.DownloadPackageReadmeOrNullAsync(id, version, cancellationToken);
+        }
+
+        try
+        {
+            return await _storage.GetReadmeStreamAsync(id, version, cancellationToken)
+                ?? await _upstream.DownloadPackageReadmeOrNullAsync(id, version, cancellationToken);
+        }
+        catch (IOException)
+        {
+            return await _upstream.DownloadPackageReadmeOrNullAsync(id, version, cancellationToken);
+        }
     }
 
     public async Task<Stream> GetPackageIconStreamOrNullAsync(string id, NuGetVersion version, CancellationToken cancellationToken = default)

--- a/src/BaGetter.Core/Extensions/DependencyInjectionExtensions.cs
+++ b/src/BaGetter.Core/Extensions/DependencyInjectionExtensions.cs
@@ -9,6 +9,8 @@ using BaGetter.Protocol;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace BaGetter.Core;
@@ -68,6 +70,7 @@ public static partial class DependencyInjectionExtensions
         services.AddBaGetterOptions<DatabaseOptions>(nameof(BaGetterOptions.Database));
         services.AddBaGetterOptions<FileSystemStorageOptions>(nameof(BaGetterOptions.Storage));
         services.AddBaGetterOptions<MirrorOptions>(nameof(BaGetterOptions.Mirror));
+        services.AddBaGetterOptions<FullProxyOptions>(nameof(BaGetterOptions.FullProxy));
         services.AddBaGetterOptions<RetentionOptions>(nameof(BaGetterOptions.Retention));
         services.AddBaGetterOptions<SearchOptions>(nameof(BaGetterOptions.Search));
         services.AddBaGetterOptions<StorageOptions>(nameof(BaGetterOptions.Storage));
@@ -88,7 +91,12 @@ public static partial class DependencyInjectionExtensions
         services.TryAddSingleton<ValidateStartupOptions>();
 
         services.TryAddSingleton(HttpClientFactory);
-        services.TryAddSingleton(NuGetClientFactoryFactory);
+        services.TryAddSingleton<NuGetClientFactory>(NuGetClientFactoryFactory);
+
+        services.AddMemoryCache();
+        services.TryAddSingleton<IUpstreamHostProvider, UpstreamHostProvider>();
+        services.TryAddTransient<INuGetUrlRewriter, NuGetUrlRewriter>();
+        services.TryAddSingleton<IAssetProxyService>(provider => AssetProxyServiceFactory(provider));
 
         services.TryAddScoped<DownloadsImporter>();
 
@@ -97,6 +105,7 @@ public static partial class DependencyInjectionExtensions
         services.TryAddTransient<IPackageDeletionService, PackageDeletionService>();
         services.TryAddTransient<IPackageIndexingService, PackageIndexingService>();
         services.TryAddTransient<IPackageMetadataService, DefaultPackageMetadataService>();
+        services.TryAddTransient<IPackageSearchService, PackageSearchService>();
         services.TryAddTransient<IPackageService, PackageService>();
         services.TryAddTransient<IPackageStorageService, PackageStorageService>();
         services.TryAddTransient<IServiceIndexService, BaGetterServiceIndex>();
@@ -189,6 +198,32 @@ public static partial class DependencyInjectionExtensions
         client.Timeout = TimeSpan.FromSeconds(options.PackageDownloadTimeoutSeconds);
 
         return client;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="IAssetProxyService"/> with a dedicated <see cref="HttpClient"/>
+    /// that disallows automatic redirects to prevent SSRF via upstream-controlled 3xx responses.
+    /// </summary>
+    private static AssetProxyService AssetProxyServiceFactory(IServiceProvider provider)
+    {
+        var mainClient = provider.GetRequiredService<HttpClient>();
+
+        var handler = new HttpClientHandler
+        {
+            AllowAutoRedirect = false,
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+        };
+
+        var proxyClient = new HttpClient(handler);
+        proxyClient.Timeout = mainClient.Timeout;
+        proxyClient.DefaultRequestHeaders.Add("User-Agent", mainClient.DefaultRequestHeaders.UserAgent.ToString());
+
+        return new AssetProxyService(
+            proxyClient,
+            provider.GetRequiredService<IUpstreamHostProvider>(),
+            provider.GetRequiredService<IMemoryCache>(),
+            provider.GetRequiredService<IOptions<FullProxyOptions>>(),
+            provider.GetRequiredService<ILogger<AssetProxyService>>());
     }
 
     private static NuGetClientFactory NuGetClientFactoryFactory(IServiceProvider provider)

--- a/src/BaGetter.Core/Extensions/PackageArchiveReaderExtensions.cs
+++ b/src/BaGetter.Core/Extensions/PackageArchiveReaderExtensions.cs
@@ -149,7 +149,7 @@ public static class PackageArchiveReaderExtensions
         return tags.Split(' ', StringSplitOptions.RemoveEmptyEntries);
     }
 
-    private static (Uri repositoryUrl, string repositoryType) GetRepositoryMetadata(NuspecReader nuspec)
+    internal static (Uri repositoryUrl, string repositoryType) GetRepositoryMetadata(NuspecReader nuspec)
     {
         var repository = nuspec.GetRepositoryMetadata();
 
@@ -164,12 +164,14 @@ public static class PackageArchiveReaderExtensions
             return (null, null);
         }
 
-        if (repository.Type.Length > 100)
+        var repositoryType = repository.Type ?? string.Empty;
+
+        if (repositoryType.Length > 100)
         {
             throw new InvalidOperationException("Repository type must be less than or equal 100 characters");
         }
 
-        return (repositoryUri, repository.Type);
+        return (repositoryUri, repositoryType);
     }
 
     private static List<PackageDependency> GetDependencies(NuspecReader nuspec)

--- a/src/BaGetter.Core/IUrlGenerator.cs
+++ b/src/BaGetter.Core/IUrlGenerator.cs
@@ -101,4 +101,11 @@ public interface IUrlGenerator
     /// <param name="id">The package's ID</param>
     /// <param name="version">The package's version</param>
     string GetPackageIconDownloadUrl(string id, NuGetVersion version);
+
+    /// <summary>
+    /// Get the URL to proxy an upstream package-resource asset through BaGetter.
+    /// Used by full proxy mode so clients never contact the upstream directly.
+    /// </summary>
+    /// <param name="upstreamUrl">The absolute upstream asset URL to proxy.</param>
+    string GetPackageProxyUrl(string upstreamUrl);
 }

--- a/src/BaGetter.Core/Metadata/BaGetterPackageMetadata.cs
+++ b/src/BaGetter.Core/Metadata/BaGetterPackageMetadata.cs
@@ -14,7 +14,7 @@ namespace BaGetter.Core;
 public class BaGetterPackageMetadata : PackageMetadata
 {
     [JsonPropertyName("downloads")]
-    public long Downloads { get; set; }
+    public new long Downloads { get; set; }
 
     [JsonPropertyName("hasReadme")]
     public bool HasReadme { get; set; }
@@ -29,8 +29,6 @@ public class BaGetterPackageMetadata : PackageMetadata
     public string ReleaseNotes { get; set; }
 
     [JsonPropertyName("repositoryUrl")]
-    public string RepositoryUrl { get; set; }
+    public new string RepositoryUrl { get; set; }
 
-    [JsonPropertyName("repositoryType")]
-    public string RepositoryType { get; set; }
 }

--- a/src/BaGetter.Core/Metadata/DefaultPackageMetadataService.cs
+++ b/src/BaGetter.Core/Metadata/DefaultPackageMetadataService.cs
@@ -12,14 +12,17 @@ public class DefaultPackageMetadataService : IPackageMetadataService
 {
     private readonly IPackageService _packages;
     private readonly RegistrationBuilder _builder;
+    private readonly IUpstreamHostProvider _upstreamHosts;
 
-    public DefaultPackageMetadataService(IPackageService packages, RegistrationBuilder builder)
+    public DefaultPackageMetadataService(IPackageService packages, RegistrationBuilder builder, IUpstreamHostProvider upstreamHosts)
     {
         ArgumentNullException.ThrowIfNull(packages);
         ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(upstreamHosts);
 
         _packages = packages;
         _builder = builder;
+        _upstreamHosts = upstreamHosts;
     }
 
     /// <inheritdoc/>
@@ -30,6 +33,10 @@ public class DefaultPackageMetadataService : IPackageMetadataService
         {
             return null;
         }
+
+        // Warm the trusted-host snapshot so the (synchronous) URL rewriter in the
+        // builder can rewrite upstream asset URLs. No-op when full proxy is off.
+        await _upstreamHosts.EnsureResolvedAsync(cancellationToken);
 
         return _builder.BuildIndex(
             new PackageRegistration(

--- a/src/BaGetter.Core/Metadata/RegistrationBuilder.cs
+++ b/src/BaGetter.Core/Metadata/RegistrationBuilder.cs
@@ -8,12 +8,15 @@ namespace BaGetter.Core;
 public class RegistrationBuilder
 {
     private readonly IUrlGenerator _url;
+    private readonly INuGetUrlRewriter _rewriter;
 
-    public RegistrationBuilder(IUrlGenerator url)
+    public RegistrationBuilder(IUrlGenerator url, INuGetUrlRewriter rewriter)
     {
         ArgumentNullException.ThrowIfNull(url);
+        ArgumentNullException.ThrowIfNull(rewriter);
 
         _url = url;
+        _rewriter = rewriter;
     }
 
     public virtual BaGetterRegistrationIndexResponse BuildIndex(PackageRegistration registration)
@@ -76,9 +79,9 @@ public class RegistrationBuilder
                 HasReadme = package.HasReadme,
                 IconUrl = package.HasEmbeddedIcon
                     ? _url.GetPackageIconDownloadUrl(package.Id, package.Version)
-                    : package.IconUrlString,
+                    : _rewriter.RewriteAssetUrl(package.IconUrlString),
                 Language = package.Language,
-                LicenseUrl = package.LicenseUrlString,
+                LicenseUrl = _rewriter.RewriteAssetUrl(package.LicenseUrlString),
                 Listed = package.Listed,
                 MinClientVersion = package.MinClientVersion,
                 ReleaseNotes = package.ReleaseNotes,

--- a/src/BaGetter.Core/PackageService.cs
+++ b/src/BaGetter.Core/PackageService.cs
@@ -57,6 +57,14 @@ public class PackageService : IPackageService
 
         foreach (var localPackage in local)
         {
+            if (result.TryGetValue(localPackage.Key, out var upstreamPackage))
+            {
+                var mergedPackage = ClonePackage(localPackage.Value);
+                MergeUpstreamMetadata(mergedPackage, upstreamPackage);
+                result[localPackage.Key] = mergedPackage;
+                continue;
+            }
+
             result[localPackage.Key] = localPackage.Value;
         }
 
@@ -145,5 +153,113 @@ public class PackageService : IPackageService
 
             return false;
         }
+    }
+
+    private static void MergeUpstreamMetadata(Package local, Package upstream)
+    {
+        local.Downloads += upstream.Downloads;
+        local.HasReadme = local.HasReadme || upstream.HasReadme;
+
+        // Cached upstream packages are indexed at cache time. Use upstream
+        // visibility metadata so package pages do not show the cache timestamp.
+        if (ShouldUseUpstreamVisibilityMetadata(local, upstream))
+        {
+            local.Published = upstream.Published;
+            local.Listed = upstream.Listed;
+        }
+
+        local.IconUrl ??= upstream.IconUrl;
+        local.LicenseUrl ??= upstream.LicenseUrl;
+        local.ProjectUrl ??= upstream.ProjectUrl;
+        local.RepositoryUrl ??= upstream.RepositoryUrl;
+
+        if (string.IsNullOrEmpty(local.RepositoryType))
+        {
+            local.RepositoryType = upstream.RepositoryType;
+        }
+
+        if (string.IsNullOrEmpty(local.Language))
+        {
+            local.Language = upstream.Language;
+        }
+
+        if (string.IsNullOrEmpty(local.MinClientVersion))
+        {
+            local.MinClientVersion = upstream.MinClientVersion;
+        }
+
+        if (string.IsNullOrEmpty(local.Summary))
+        {
+            local.Summary = upstream.Summary;
+        }
+
+        if (string.IsNullOrEmpty(local.Title))
+        {
+            local.Title = upstream.Title;
+        }
+
+        if (string.IsNullOrEmpty(local.Description))
+        {
+            local.Description = upstream.Description;
+        }
+
+        if ((local.Tags?.Length ?? 0) == 0)
+        {
+            local.Tags = upstream.Tags;
+        }
+
+        if ((local.Authors?.Length ?? 0) == 0)
+        {
+            local.Authors = upstream.Authors;
+        }
+    }
+
+    private static bool ShouldUseUpstreamVisibilityMetadata(Package local, Package upstream)
+    {
+        if (!string.IsNullOrEmpty(local.CachedFrom))
+        {
+            return true;
+        }
+
+        // Packages cached before cache provenance was persisted have no
+        // CachedFrom value, but their local publish date is the cache time.
+        return upstream.Published != default && local.Published > upstream.Published;
+    }
+
+    private static Package ClonePackage(Package package)
+    {
+        return new Package
+        {
+            Key = package.Key,
+            Id = package.Id,
+            Authors = package.Authors?.ToArray(),
+            Description = package.Description,
+            Downloads = package.Downloads,
+            HasReadme = package.HasReadme,
+            HasEmbeddedIcon = package.HasEmbeddedIcon,
+            IsPrerelease = package.IsPrerelease,
+            CachedFrom = package.CachedFrom,
+            ReleaseNotes = package.ReleaseNotes,
+            Language = package.Language,
+            Listed = package.Listed,
+            MinClientVersion = package.MinClientVersion,
+            Published = package.Published,
+            RequireLicenseAcceptance = package.RequireLicenseAcceptance,
+            SemVerLevel = package.SemVerLevel,
+            Summary = package.Summary,
+            Title = package.Title,
+            IconUrl = package.IconUrl,
+            LicenseUrl = package.LicenseUrl,
+            ProjectUrl = package.ProjectUrl,
+            RepositoryUrl = package.RepositoryUrl,
+            RepositoryType = package.RepositoryType,
+            Tags = package.Tags?.ToArray(),
+            RowVersion = package.RowVersion?.ToArray(),
+            Dependencies = package.Dependencies?.ToList(),
+            PackageTypes = package.PackageTypes?.ToList(),
+            TargetFrameworks = package.TargetFrameworks?.ToList(),
+            NormalizedVersionString = package.NormalizedVersionString,
+            OriginalVersionString = package.OriginalVersionString,
+        };
     }
 }

--- a/src/BaGetter.Core/Proxy/AssetProxyService.cs
+++ b/src/BaGetter.Core/Proxy/AssetProxyService.cs
@@ -1,0 +1,188 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BaGetter.Core;
+
+/// <inheritdoc/>
+public class AssetProxyService : IAssetProxyService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IUpstreamHostProvider _hosts;
+    private readonly IMemoryCache _cache;
+    private readonly FullProxyOptions _options;
+    private readonly ILogger<AssetProxyService> _logger;
+
+    public AssetProxyService(
+        HttpClient httpClient,
+        IUpstreamHostProvider hosts,
+        IMemoryCache cache,
+        IOptions<FullProxyOptions> options,
+        ILogger<AssetProxyService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(hosts);
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _httpClient = httpClient;
+        _hosts = hosts;
+        _cache = cache;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<AssetProxyResult> GetAssetAsync(string url, CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled)
+        {
+            return AssetProxyResult.Rejected;
+        }
+
+        await _hosts.EnsureResolvedAsync(cancellationToken);
+
+        if (!TryValidate(url, out var uri) || !_hosts.IsTrustedHost(uri.Host))
+        {
+            return AssetProxyResult.Rejected;
+        }
+
+        // Defense in depth: reject hosts that resolve to loopback/private/link-local
+        // addresses, even if they slipped into the trusted set (DNS rebinding).
+        if (await ResolvesToDisallowedAddressCachedAsync(uri.Host, cancellationToken))
+        {
+            return AssetProxyResult.Rejected;
+        }
+
+        var cacheKey = "fullproxy:asset:" + uri.AbsoluteUri;
+        if (_cache.TryGetValue(cacheKey, out CachedAsset cached))
+        {
+            return AssetProxyResult.Ok(new MemoryStream(cached.Content, writable: false), cached.ContentType);
+        }
+
+        try
+        {
+            using var response = await _httpClient.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                return AssetProxyResult.NotFound;
+            }
+
+            var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+            var contentType = response.Content.Headers.ContentType?.ToString() ?? "application/octet-stream";
+
+            if (_options.AssetCacheMinutes > 0)
+            {
+                _cache.Set(
+                    cacheKey,
+                    new CachedAsset(bytes, contentType),
+                    TimeSpan.FromMinutes(_options.AssetCacheMinutes));
+            }
+
+            return AssetProxyResult.Ok(new MemoryStream(bytes, writable: false), contentType);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to proxy upstream asset {Url}", uri);
+            return AssetProxyResult.NotFound;
+        }
+    }
+
+    /// <summary>
+    /// Validate that <paramref name="url"/> is an absolute HTTPS URL. Pure helper
+    /// (no host-allowlist or DNS check) for unit testing.
+    /// </summary>
+    public static bool TryValidate(string url, out Uri uri)
+    {
+        uri = null;
+        if (string.IsNullOrWhiteSpace(url) || !Uri.TryCreate(url, UriKind.Absolute, out var parsed))
+        {
+            return false;
+        }
+
+        if (parsed.Scheme != Uri.UriSchemeHttps)
+        {
+            return false;
+        }
+
+        uri = parsed;
+        return true;
+    }
+
+    /// <summary>
+    /// Whether an IP address is loopback, private, link-local or unique-local and
+    /// must not be proxied. Pure helper for unit testing.
+    /// </summary>
+    public static bool IsDisallowedAddress(IPAddress address)
+    {
+        if (address is null || IPAddress.IsLoopback(address))
+        {
+            return true;
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetwork)
+        {
+            var b = address.GetAddressBytes();
+            return b[0] == 10                                   // 10.0.0.0/8
+                || (b[0] == 172 && b[1] >= 16 && b[1] <= 31)    // 172.16.0.0/12
+                || (b[0] == 192 && b[1] == 168)                 // 192.168.0.0/16
+                || (b[0] == 169 && b[1] == 254);                // 169.254.0.0/16 (incl. cloud metadata)
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            if (address.IsIPv4MappedToIPv6)
+            {
+                return IsDisallowedAddress(address.MapToIPv4());
+            }
+
+            return address.IsIPv6LinkLocal      // fe80::/10
+                || address.IsIPv6SiteLocal       // fec0::/10 (deprecated)
+                || address.IsIPv6UniqueLocal;    // fc00::/7
+        }
+
+        return false;
+    }
+
+    private async Task<bool> ResolvesToDisallowedAddressCachedAsync(string host, CancellationToken cancellationToken)
+    {
+        var cacheKey = "dns:" + host;
+        if (_cache.TryGetValue(cacheKey, out bool cached))
+        {
+            return cached;
+        }
+
+        var result = await ResolvesToDisallowedAddressAsync(host, cancellationToken);
+        _cache.Set(cacheKey, result, TimeSpan.FromMinutes(5));
+        return result;
+    }
+
+    private static async Task<bool> ResolvesToDisallowedAddressAsync(string host, CancellationToken cancellationToken)
+    {
+        if (IPAddress.TryParse(host, out var literal))
+        {
+            return IsDisallowedAddress(literal);
+        }
+
+        try
+        {
+            var addresses = await Dns.GetHostAddressesAsync(host, cancellationToken);
+            return addresses.Length == 0 || addresses.Any(IsDisallowedAddress);
+        }
+        catch (SocketException)
+        {
+            return true;
+        }
+    }
+
+    private sealed record CachedAsset(byte[] Content, string ContentType);
+}

--- a/src/BaGetter.Core/Proxy/IAssetProxyService.cs
+++ b/src/BaGetter.Core/Proxy/IAssetProxyService.cs
@@ -1,0 +1,43 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BaGetter.Core;
+
+/// <summary>
+/// Fetches upstream package-resource assets server-side so clients never contact
+/// the upstream directly. Enforces SSRF protection: only HTTPS URLs on trusted
+/// upstream hosts that do not resolve to loopback/private addresses are fetched.
+/// </summary>
+public interface IAssetProxyService
+{
+    /// <summary>
+    /// Fetch an upstream asset server-side.
+    /// </summary>
+    Task<AssetProxyResult> GetAssetAsync(string url, CancellationToken cancellationToken);
+}
+
+public enum AssetProxyStatus
+{
+    /// <summary>The asset was fetched successfully.</summary>
+    Ok,
+
+    /// <summary>The URL is not an allowed upstream asset URL (SSRF protection).</summary>
+    Rejected,
+
+    /// <summary>The URL was allowed but the asset could not be fetched.</summary>
+    NotFound,
+}
+
+public sealed class AssetProxyResult
+{
+    public AssetProxyStatus Status { get; private init; }
+    public Stream Content { get; private init; }
+    public string ContentType { get; private init; }
+
+    public static readonly AssetProxyResult Rejected = new() { Status = AssetProxyStatus.Rejected };
+    public static readonly AssetProxyResult NotFound = new() { Status = AssetProxyStatus.NotFound };
+
+    public static AssetProxyResult Ok(Stream content, string contentType) =>
+        new() { Status = AssetProxyStatus.Ok, Content = content, ContentType = contentType };
+}

--- a/src/BaGetter.Core/Proxy/INuGetUrlRewriter.cs
+++ b/src/BaGetter.Core/Proxy/INuGetUrlRewriter.cs
@@ -1,0 +1,18 @@
+namespace BaGetter.Core;
+
+/// <summary>
+/// Rewrites upstream package-resource asset URLs to BaGetter asset-proxy URLs
+/// when full proxy mode is enabled, so the asset is fetched server-side instead
+/// of by the client. URLs that are not trusted upstream infrastructure are
+/// returned unchanged. This is the single, reusable rewriting layer used by both
+/// metadata and search.
+/// </summary>
+public interface INuGetUrlRewriter
+{
+    /// <summary>
+    /// Rewrite a single asset URL. Returns the input unchanged when full proxy is
+    /// disabled, the URL is not an absolute HTTPS URL, or its host is not a
+    /// trusted upstream host.
+    /// </summary>
+    string RewriteAssetUrl(string url);
+}

--- a/src/BaGetter.Core/Proxy/IUpstreamHostProvider.cs
+++ b/src/BaGetter.Core/Proxy/IUpstreamHostProvider.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BaGetter.Core;
+
+/// <summary>
+/// Provides the set of hosts that are considered trusted upstream
+/// infrastructure for the configured mirror. The set is derived from the
+/// upstream package source and its service index, so full proxy works for any
+/// provider without a hard-coded host list.
+/// </summary>
+public interface IUpstreamHostProvider
+{
+    /// <summary>
+    /// Ensure the trusted host set has been resolved and cached. No-op when full
+    /// proxy or mirroring is disabled.
+    /// </summary>
+    Task EnsureResolvedAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Whether the given host is a trusted upstream host. Returns
+    /// <see langword="false"/> if the set has not been resolved yet (call
+    /// <see cref="EnsureResolvedAsync"/> first).
+    /// </summary>
+    bool IsTrustedHost(string host);
+}

--- a/src/BaGetter.Core/Proxy/NuGetUrlRewriter.cs
+++ b/src/BaGetter.Core/Proxy/NuGetUrlRewriter.cs
@@ -1,0 +1,44 @@
+using System;
+using Microsoft.Extensions.Options;
+
+namespace BaGetter.Core;
+
+/// <inheritdoc/>
+public class NuGetUrlRewriter : INuGetUrlRewriter
+{
+    private readonly FullProxyOptions _options;
+    private readonly IUpstreamHostProvider _hosts;
+    private readonly IUrlGenerator _url;
+
+    public NuGetUrlRewriter(
+        IOptions<FullProxyOptions> options,
+        IUpstreamHostProvider hosts,
+        IUrlGenerator url)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(hosts);
+        ArgumentNullException.ThrowIfNull(url);
+
+        _options = options.Value;
+        _hosts = hosts;
+        _url = url;
+    }
+
+    /// <inheritdoc/>
+    public string RewriteAssetUrl(string url)
+    {
+        if (!_options.Enabled || string.IsNullOrWhiteSpace(url))
+        {
+            return url;
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            || uri.Scheme != Uri.UriSchemeHttps
+            || !_hosts.IsTrustedHost(uri.Host))
+        {
+            return url;
+        }
+
+        return _url.GetPackageProxyUrl(url) ?? url;
+    }
+}

--- a/src/BaGetter.Core/Proxy/UpstreamHostProvider.cs
+++ b/src/BaGetter.Core/Proxy/UpstreamHostProvider.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BaGetter.Protocol;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BaGetter.Core;
+
+/// <summary>
+/// Derives the trusted upstream host set from the configured mirror: the package
+/// source host plus every host advertised by the upstream service index. The set
+/// is resolved once and cached for the lifetime of the application.
+/// </summary>
+public class UpstreamHostProvider : IUpstreamHostProvider
+{
+    private readonly NuGetClientFactory _clientFactory;
+    private readonly MirrorOptions _mirror;
+    private readonly FullProxyOptions _fullProxy;
+    private readonly ILogger<UpstreamHostProvider> _logger;
+    private readonly SemaphoreSlim _mutex = new(1, 1);
+
+    private volatile HashSet<string> _hosts;
+
+    public UpstreamHostProvider(
+        NuGetClientFactory clientFactory,
+        IOptions<MirrorOptions> mirror,
+        IOptions<FullProxyOptions> fullProxy,
+        ILogger<UpstreamHostProvider> logger)
+    {
+        ArgumentNullException.ThrowIfNull(clientFactory);
+        ArgumentNullException.ThrowIfNull(mirror);
+        ArgumentNullException.ThrowIfNull(fullProxy);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _clientFactory = clientFactory;
+        _mirror = mirror.Value;
+        _fullProxy = fullProxy.Value;
+        _logger = logger;
+    }
+
+    public async Task EnsureResolvedAsync(CancellationToken cancellationToken)
+    {
+        if (!_fullProxy.Enabled || !_mirror.Enabled || _hosts != null)
+        {
+            return;
+        }
+
+        await _mutex.WaitAsync(cancellationToken);
+        try
+        {
+            if (_hosts != null)
+            {
+                return;
+            }
+
+            var hosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            var sourceHost = _mirror.PackageSource?.Host;
+            if (!string.IsNullOrEmpty(sourceHost))
+            {
+                hosts.Add(sourceHost);
+            }
+
+            try
+            {
+                // Resolve lazily so mirror-disabled installations do not need a
+                // configured package source just to construct the provider.
+                var serviceIndex = await _clientFactory
+                    .CreateServiceIndexClient()
+                    .GetAsync(cancellationToken);
+
+                foreach (var resource in serviceIndex.Resources ?? [])
+                {
+                    if (Uri.TryCreate(resource.ResourceUrl, UriKind.Absolute, out var uri))
+                    {
+                        hosts.Add(uri.Host);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                // Legacy (v2) upstreams or transient failures: fall back to the
+                // package source host only.
+                _logger.LogWarning(e, "Failed to resolve upstream service index hosts for full proxy; using package source host only");
+            }
+
+            _hosts = hosts;
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    public bool IsTrustedHost(string host)
+    {
+        if (string.IsNullOrEmpty(host))
+        {
+            return false;
+        }
+
+        var hosts = _hosts;
+        return hosts != null && hosts.Contains(host);
+    }
+}

--- a/src/BaGetter.Core/Search/IPackageSearchService.cs
+++ b/src/BaGetter.Core/Search/IPackageSearchService.cs
@@ -1,0 +1,9 @@
+namespace BaGetter.Core;
+
+/// <summary>
+/// Search service exposed to NuGet clients and the web UI. It wraps the configured
+/// local search provider with optional upstream search and full-proxy URL rewriting.
+/// </summary>
+public interface IPackageSearchService : ISearchService
+{
+}

--- a/src/BaGetter.Core/Search/PackageSearchService.cs
+++ b/src/BaGetter.Core/Search/PackageSearchService.cs
@@ -1,0 +1,420 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BaGetter.Protocol.Models;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using NuGet.Versioning;
+
+namespace BaGetter.Core;
+
+/// <summary>
+/// Combines the configured local search provider with optional upstream search.
+/// Full proxy mode also uses this layer to rewrite package-resource URLs before
+/// they are returned to clients.
+/// </summary>
+public class PackageSearchService : IPackageSearchService
+{
+    private readonly ISearchService _local;
+    private readonly IUpstreamClient _upstream;
+    private readonly IUrlGenerator _url;
+    private readonly INuGetUrlRewriter _rewriter;
+    private readonly IUpstreamHostProvider _upstreamHosts;
+    private readonly IMemoryCache _cache;
+    private readonly SearchOptions _options;
+    private readonly FullProxyOptions _fullProxy;
+
+    public PackageSearchService(
+        ISearchService local,
+        IUpstreamClient upstream,
+        IUrlGenerator url,
+        INuGetUrlRewriter rewriter,
+        IUpstreamHostProvider upstreamHosts,
+        IMemoryCache cache,
+        IOptions<SearchOptions> options,
+        IOptions<FullProxyOptions> fullProxyOptions)
+    {
+        ArgumentNullException.ThrowIfNull(local);
+        ArgumentNullException.ThrowIfNull(upstream);
+        ArgumentNullException.ThrowIfNull(url);
+        ArgumentNullException.ThrowIfNull(rewriter);
+        ArgumentNullException.ThrowIfNull(upstreamHosts);
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(fullProxyOptions);
+
+        _local = local;
+        _upstream = upstream;
+        _url = url;
+        _rewriter = rewriter;
+        _upstreamHosts = upstreamHosts;
+        _cache = cache;
+        _options = options.Value;
+        _fullProxy = fullProxyOptions.Value;
+    }
+
+    // Full proxy implies upstream search: clients cannot reach the upstream, so
+    // BaGetter must serve upstream results regardless of the explicit setting.
+    private bool IncludeUpstream => _options.IncludeUpstream || _fullProxy.Enabled;
+
+    public async Task<SearchResponse> SearchAsync(
+        SearchRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!IncludeUpstream)
+        {
+            return await _local.SearchAsync(request, cancellationToken);
+        }
+
+        await _upstreamHosts.EnsureResolvedAsync(cancellationToken);
+
+        var expandedRequest = new SearchRequest
+        {
+            Skip = 0,
+            Take = request.Skip + request.Take,
+            IncludePrerelease = request.IncludePrerelease,
+            IncludeSemVer2 = request.IncludeSemVer2,
+            PackageType = request.PackageType,
+            Framework = request.Framework,
+            Query = request.Query
+        };
+
+        var localTask = _local.SearchAsync(expandedRequest, cancellationToken);
+        var upstreamTask = UpstreamSearchAsync(
+            request.Query,
+            take: expandedRequest.Take,
+            includePrerelease: request.IncludePrerelease,
+            includeSemVer2: request.IncludeSemVer2,
+            cancellationToken: cancellationToken);
+
+        await Task.WhenAll(localTask, upstreamTask);
+
+        var local = await localTask;
+        var upstream = (await upstreamTask)
+            .Select(result => FilterVersions(result, request))
+            .Where(result => result != null)
+            .Where(result => MatchesPackageType(result, request.PackageType))
+            .ToList();
+
+        var upstreamIds = new HashSet<string>(
+            upstream.Select(result => result.PackageId),
+            StringComparer.OrdinalIgnoreCase);
+
+        var merged = MergeSearchResults(
+                local.Data ?? Array.Empty<SearchResult>(),
+                upstream)
+            .Select(RewriteUrls)
+            .ToList();
+
+        var data = merged
+            .Skip(request.Skip)
+            .Take(request.Take)
+            .ToList();
+
+        await EnrichLocalOnlyDownloadCountsAsync(data, upstreamIds, cancellationToken);
+
+        return new SearchResponse
+        {
+            TotalHits = merged.Count,
+            Data = data,
+            Context = SearchContext.Default(_url.GetPackageMetadataResourceUrl())
+        };
+    }
+
+    public async Task<AutocompleteResponse> AutocompleteAsync(
+        AutocompleteRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!IncludeUpstream)
+        {
+            return await _local.AutocompleteAsync(request, cancellationToken);
+        }
+
+        var expandedRequest = new AutocompleteRequest
+        {
+            Skip = 0,
+            Take = request.Skip + request.Take,
+            IncludePrerelease = request.IncludePrerelease,
+            IncludeSemVer2 = request.IncludeSemVer2,
+            PackageType = request.PackageType,
+            Query = request.Query
+        };
+
+        var localTask = _local.AutocompleteAsync(expandedRequest, cancellationToken);
+        var upstreamTask = UpstreamAutocompleteAsync(
+            request.Query,
+            take: expandedRequest.Take,
+            includePrerelease: request.IncludePrerelease,
+            cancellationToken: cancellationToken);
+
+        await Task.WhenAll(localTask, upstreamTask);
+
+        var merged = ((await localTask).Data ?? Array.Empty<string>())
+            .Concat(await upstreamTask)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var data = merged
+            .Skip(request.Skip)
+            .Take(request.Take)
+            .ToList();
+
+        return new AutocompleteResponse
+        {
+            TotalHits = merged.Count,
+            Data = data,
+            Context = AutocompleteContext.Default
+        };
+    }
+
+    public async Task<AutocompleteResponse> ListPackageVersionsAsync(
+        VersionsRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!IncludeUpstream)
+        {
+            return await _local.ListPackageVersionsAsync(request, cancellationToken);
+        }
+
+        var localTask = _local.ListPackageVersionsAsync(request, cancellationToken);
+        var upstreamTask = _upstream.ListPackageVersionsAsync(request.PackageId, cancellationToken);
+
+        await Task.WhenAll(localTask, upstreamTask);
+
+        var data = ((await localTask).Data ?? Array.Empty<string>())
+            .Select(NuGetVersion.Parse)
+            .Concat(await upstreamTask)
+            .Where(version => request.IncludePrerelease || !version.IsPrerelease)
+            .Where(version => request.IncludeSemVer2 || !version.IsSemVer2)
+            .Distinct()
+            .OrderBy(version => version)
+            .Select(version => version.ToNormalizedString().ToLowerInvariant())
+            .ToList();
+
+        return new AutocompleteResponse
+        {
+            TotalHits = data.Count,
+            Data = data,
+            Context = AutocompleteContext.Default
+        };
+    }
+
+    public Task<DependentsResponse> FindDependentsAsync(
+        string packageId,
+        CancellationToken cancellationToken)
+    {
+        return _local.FindDependentsAsync(packageId, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<SearchResult>> UpstreamSearchAsync(
+        string query,
+        int take,
+        bool includePrerelease,
+        bool includeSemVer2,
+        CancellationToken cancellationToken)
+    {
+        if (!UseUpstreamCache)
+        {
+            return await _upstream.SearchAsync(query, skip: 0, take, includePrerelease, cancellationToken);
+        }
+
+        var key = $"fullproxy:search:{includePrerelease}:{includeSemVer2}:{take}:{query}";
+        if (_cache.TryGetValue(key, out IReadOnlyList<SearchResult> cached))
+        {
+            return cached;
+        }
+
+        var result = await _upstream.SearchAsync(query, skip: 0, take, includePrerelease, cancellationToken);
+        _cache.Set(key, result, TimeSpan.FromMinutes(_fullProxy.CacheMinutes));
+        return result;
+    }
+
+    private async Task<IReadOnlyList<string>> UpstreamAutocompleteAsync(
+        string query,
+        int take,
+        bool includePrerelease,
+        CancellationToken cancellationToken)
+    {
+        if (!UseUpstreamCache)
+        {
+            return await _upstream.AutocompleteAsync(query, skip: 0, take, includePrerelease, cancellationToken);
+        }
+
+        var key = $"fullproxy:autocomplete:{includePrerelease}:{take}:{query}";
+        if (_cache.TryGetValue(key, out IReadOnlyList<string> cached))
+        {
+            return cached;
+        }
+
+        var result = await _upstream.AutocompleteAsync(query, skip: 0, take, includePrerelease, cancellationToken);
+        _cache.Set(key, result, TimeSpan.FromMinutes(_fullProxy.CacheMinutes));
+        return result;
+    }
+
+    private bool UseUpstreamCache => _fullProxy.Enabled && _fullProxy.CacheMinutes > 0;
+
+    private static SearchResult FilterVersions(SearchResult result, SearchRequest request)
+    {
+        if (result?.Versions == null)
+        {
+            return result;
+        }
+
+        var versions = result.Versions
+            .Where(version => NuGetVersion.TryParse(version.Version, out _))
+            .Where(version =>
+            {
+                var parsed = NuGetVersion.Parse(version.Version);
+                return (request.IncludePrerelease || !parsed.IsPrerelease)
+                    && (request.IncludeSemVer2 || !parsed.IsSemVer2);
+            })
+            .OrderByDescending(version => NuGetVersion.Parse(version.Version))
+            .ToList();
+
+        if (versions.Count == 0)
+        {
+            return null;
+        }
+
+        result.Versions = versions;
+        result.Version = versions[0].Version;
+        return result;
+    }
+
+    private SearchResult RewriteUrls(SearchResult result)
+    {
+        result.RegistrationIndexUrl = _url.GetRegistrationIndexUrl(result.PackageId);
+        result.IconUrl = _rewriter.RewriteAssetUrl(result.IconUrl);
+        result.LicenseUrl = _rewriter.RewriteAssetUrl(result.LicenseUrl);
+
+        if (result.Versions != null)
+        {
+            foreach (var version in result.Versions)
+            {
+                if (NuGetVersion.TryParse(version.Version, out var nugetVersion))
+                {
+                    version.RegistrationLeafUrl = _url.GetRegistrationLeafUrl(
+                        result.PackageId,
+                        nugetVersion);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Filter upstream search results by the requested package type.
+    /// Packages with no declared types default to "Dependency".
+    /// </summary>
+    private static bool MatchesPackageType(SearchResult result, string packageType)
+    {
+        if (string.IsNullOrEmpty(packageType)) return true;
+
+        if (result.PackageTypes is null || result.PackageTypes.Count == 0)
+        {
+            return string.Equals("dependency", packageType, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return result.PackageTypes.Any(t =>
+            string.Equals(t.Name, packageType, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Merge local and upstream results, deduplicating by package ID.
+    /// Upstream results that overlap with local results add their download
+    /// counts to the local counts.
+    /// </summary>
+    private static IEnumerable<SearchResult> MergeSearchResults(
+        IReadOnlyList<SearchResult> local,
+        IEnumerable<SearchResult> upstream)
+    {
+        var results = new Dictionary<string, SearchResult>(StringComparer.OrdinalIgnoreCase);
+        var order = new List<string>();
+
+        foreach (var result in local.Concat(upstream))
+        {
+            if (!results.TryGetValue(result.PackageId, out var existing))
+            {
+                results[result.PackageId] = result;
+                order.Add(result.PackageId);
+                continue;
+            }
+
+            var versions = (existing.Versions ?? Array.Empty<SearchResultVersion>())
+                .Concat(result.Versions ?? Array.Empty<SearchResultVersion>())
+                .GroupBy(version => version.Version, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
+                .OrderByDescending(version => NuGetVersion.Parse(version.Version))
+                .ToList();
+
+            existing.Versions = versions;
+            if (versions.Count > 0)
+            {
+                existing.Version = versions[0].Version;
+            }
+
+            existing.TotalDownloads += result.TotalDownloads;
+        }
+
+        return order.Select(id => results[id]);
+    }
+
+    /// <summary>
+    /// For displayed local-only results, fetch upstream download counts and
+    /// cache them. This keeps locally mirrored packages from showing only their
+    /// local cache count when the package did not overlap the upstream search page.
+    /// </summary>
+    private async Task EnrichLocalOnlyDownloadCountsAsync(
+        List<SearchResult> results,
+        HashSet<string> upstreamIds,
+        CancellationToken cancellationToken)
+    {
+        var candidates = results
+            .Where(result => !upstreamIds.Contains(result.PackageId))
+            .ToList();
+
+        foreach (var result in candidates)
+        {
+            var cacheKey = "upstream:dl:" + result.PackageId;
+            var notFoundKey = "upstream:nf:" + result.PackageId;
+
+            if (_cache.TryGetValue(notFoundKey, out _))
+                continue;
+
+            if (_cache.TryGetValue(cacheKey, out long cachedDownloads))
+            {
+                result.TotalDownloads += cachedDownloads;
+                continue;
+            }
+
+            try
+            {
+                var upstreamResults = await _upstream.SearchAsync(
+                    result.PackageId,
+                    skip: 0,
+                    take: 10,
+                    includePrerelease: true,
+                    cancellationToken);
+
+                var match = upstreamResults.FirstOrDefault(
+                    r => string.Equals(r.PackageId, result.PackageId, StringComparison.OrdinalIgnoreCase));
+
+                if (match != null && match.TotalDownloads > 0)
+                {
+                    _cache.Set(cacheKey, match.TotalDownloads, TimeSpan.FromHours(1));
+                    result.TotalDownloads += match.TotalDownloads;
+                }
+                else
+                {
+                    _cache.Set(notFoundKey, true, TimeSpan.FromMinutes(30));
+                }
+            }
+            catch
+            {
+                // Best-effort; don't cache failures so the next search retries.
+            }
+        }
+    }
+}

--- a/src/BaGetter.Core/Upstream/Clients/DisabledUpstreamClient.cs
+++ b/src/BaGetter.Core/Upstream/Clients/DisabledUpstreamClient.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using BaGetter.Protocol.Models;
 using NuGet.Versioning;
 
 namespace BaGetter.Core;
@@ -13,6 +14,28 @@ public class DisabledUpstreamClient : IUpstreamClient
 {
     private readonly IReadOnlyList<NuGetVersion> _emptyVersionList = new List<NuGetVersion>();
     private readonly IReadOnlyList<Package> _emptyPackageList = new List<Package>();
+    private readonly IReadOnlyList<SearchResult> _emptySearchResultList = new List<SearchResult>();
+    private readonly IReadOnlyList<string> _emptyStringList = new List<string>();
+
+    public Task<IReadOnlyList<SearchResult>> SearchAsync(
+        string query,
+        int skip,
+        int take,
+        bool includePrerelease,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_emptySearchResultList);
+    }
+
+    public Task<IReadOnlyList<string>> AutocompleteAsync(
+        string query,
+        int skip,
+        int take,
+        bool includePrerelease,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_emptyStringList);
+    }
 
     public Task<IReadOnlyList<NuGetVersion>> ListPackageVersionsAsync(string id, CancellationToken cancellationToken)
     {
@@ -24,7 +47,20 @@ public class DisabledUpstreamClient : IUpstreamClient
         return Task.FromResult(_emptyPackageList);
     }
 
+    public Task EnrichPackageMetadataAsync(Package package, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
     public Task<Stream> DownloadPackageOrNullAsync(
+        string id,
+        NuGetVersion version,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult<Stream>(null);
+    }
+
+    public Task<Stream> DownloadPackageReadmeOrNullAsync(
         string id,
         NuGetVersion version,
         CancellationToken cancellationToken)

--- a/src/BaGetter.Core/Upstream/Clients/V2UpstreamClient.cs
+++ b/src/BaGetter.Core/Upstream/Clients/V2UpstreamClient.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using BaGetter.Protocol.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NuGet.Common;
@@ -70,6 +71,50 @@ public class V2UpstreamClient : IUpstreamClient, IDisposable
 
     public string GetServiceIndexUrl() => _repository.PackageSource.Source;
 
+    public async Task<IReadOnlyList<SearchResult>> SearchAsync(
+        string query,
+        int skip,
+        int take,
+        bool includePrerelease,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var resource = await _repository.GetResourceAsync<PackageSearchResource>(cancellationToken);
+            var packages = await resource.SearchAsync(
+                query ?? string.Empty,
+                new SearchFilter(includePrerelease),
+                skip,
+                take,
+                _ngLogger,
+                cancellationToken);
+
+            return packages.Select(ToSearchResult).ToList();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to search upstream packages");
+            return new List<SearchResult>();
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> AutocompleteAsync(
+        string query,
+        int skip,
+        int take,
+        bool includePrerelease,
+        CancellationToken cancellationToken)
+    {
+        var results = await SearchAsync(
+            query,
+            skip,
+            take,
+            includePrerelease,
+            cancellationToken);
+
+        return results.Select(result => result.PackageId).ToList();
+    }
+
     public async Task<IReadOnlyList<NuGetVersion>> ListPackageVersionsAsync(string id, CancellationToken cancellationToken)
     {
         try
@@ -110,6 +155,40 @@ public class V2UpstreamClient : IUpstreamClient, IDisposable
         }
     }
 
+    public async Task EnrichPackageMetadataAsync(Package package, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+
+        try
+        {
+            using var packageStream = await DownloadPackageOrNullAsync(package.Id, package.Version, cancellationToken);
+            if (packageStream == null)
+            {
+                return;
+            }
+
+            using var packageReader = new PackageArchiveReader(packageStream);
+            var metadata = packageReader.GetPackageMetadata();
+
+            package.HasReadme = package.HasReadme || metadata.HasReadme;
+            package.ProjectUrl ??= metadata.ProjectUrl;
+            package.RepositoryUrl ??= metadata.RepositoryUrl;
+
+            if (string.IsNullOrEmpty(package.RepositoryType))
+            {
+                package.RepositoryType = metadata.RepositoryType;
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(
+                e,
+                "Failed to read {PackageId} {PackageVersion}'s upstream metadata",
+                package.Id,
+                package.Version);
+        }
+    }
+
     public async Task<Stream> DownloadPackageOrNullAsync(
         string id,
         NuGetVersion version,
@@ -147,6 +226,39 @@ public class V2UpstreamClient : IUpstreamClient, IDisposable
         }
     }
 
+    public async Task<Stream> DownloadPackageReadmeOrNullAsync(
+        string id,
+        NuGetVersion version,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var packageStream = await DownloadPackageOrNullAsync(id, version, cancellationToken);
+            if (packageStream == null)
+            {
+                return null;
+            }
+
+            using var packageReader = new PackageArchiveReader(packageStream);
+            if (!packageReader.HasReadme())
+            {
+                return null;
+            }
+
+            await using var readmeStream = await packageReader.GetReadmeAsync(cancellationToken);
+            return await readmeStream.AsTemporaryFileStreamAsync(cancellationToken);
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(
+                e,
+                "Failed to read {PackageId} {PackageVersion}'s upstream readme",
+                id,
+                version);
+            return null;
+        }
+    }
+
     public void Dispose()
     {
         _cache.Dispose();
@@ -161,7 +273,7 @@ public class V2UpstreamClient : IUpstreamClient, IDisposable
             Version = package.Identity.Version,
             Authors = ParseAuthors(package.Authors),
             Description = package.Description,
-            Downloads = 0,
+            Downloads = package.DownloadCount ?? 0,
             HasReadme = false,
             Language = null,
             Listed = package.IsListed,
@@ -179,6 +291,34 @@ public class V2UpstreamClient : IUpstreamClient, IDisposable
             Tags = package.Tags?.Split(TagsSeparators, StringSplitOptions.RemoveEmptyEntries),
 
             Dependencies = ToDependencies(package)
+        };
+    }
+
+    private static SearchResult ToSearchResult(IPackageSearchMetadata package)
+    {
+        var version = package.Identity.Version.ToFullString();
+
+        return new SearchResult
+        {
+            PackageId = package.Identity.Id,
+            Version = version,
+            Description = package.Description,
+            Authors = ParseAuthors(package.Authors),
+            IconUrl = package.IconUrl?.AbsoluteUri ?? string.Empty,
+            LicenseUrl = package.LicenseUrl?.AbsoluteUri ?? string.Empty,
+            ProjectUrl = package.ProjectUrl?.AbsoluteUri ?? string.Empty,
+            Summary = package.Summary,
+            Tags = package.Tags?.Split(TagsSeparators, StringSplitOptions.RemoveEmptyEntries),
+            Title = package.Title,
+            TotalDownloads = package.DownloadCount ?? 0,
+            Versions =
+            [
+                new SearchResultVersion
+                {
+                    Version = version,
+                    Downloads = package.DownloadCount ?? 0
+                }
+            ]
         };
     }
 

--- a/src/BaGetter.Core/Upstream/Clients/V3UpstreamClient.cs
+++ b/src/BaGetter.Core/Upstream/Clients/V3UpstreamClient.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using BaGetter.Protocol;
 using BaGetter.Protocol.Models;
 using Microsoft.Extensions.Logging;
+using NuGet.Packaging;
 using NuGet.Versioning;
 
 namespace BaGetter.Core;
@@ -30,6 +31,52 @@ public class V3UpstreamClient : IUpstreamClient
         _logger = logger;
     }
     public string GetServiceIndexUrl() => _client.ServiceIndexUrl;
+
+    public async Task<IReadOnlyList<SearchResult>> SearchAsync(
+        string query,
+        int skip,
+        int take,
+        bool includePrerelease,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _client.SearchAsync(
+                query,
+                skip,
+                take,
+                includePrerelease,
+                cancellationToken);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to search upstream packages");
+            return new List<SearchResult>();
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> AutocompleteAsync(
+        string query,
+        int skip,
+        int take,
+        bool includePrerelease,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _client.AutocompleteAsync(
+                query,
+                skip,
+                take,
+                includePrerelease,
+                cancellationToken);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to autocomplete upstream package IDs");
+            return new List<string>();
+        }
+    }
 
     public async Task<Stream> DownloadPackageOrNullAsync(
         string id,
@@ -62,9 +109,8 @@ public class V3UpstreamClient : IUpstreamClient
     {
         try
         {
-            var packages = await _client.GetPackageMetadataAsync(id, cancellationToken);
-
-            return packages.Select(ToPackage).ToList();
+            var packageMetadata = await _client.GetPackageMetadataAsync(id, cancellationToken);
+            return packageMetadata.Select(ToPackage).ToList();
         }
         catch (Exception e)
         {
@@ -88,6 +134,80 @@ public class V3UpstreamClient : IUpstreamClient
         }
     }
 
+    public async Task EnrichPackageMetadataAsync(Package package, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+
+        if (package.HasReadme && package.RepositoryUrl != null && package.ProjectUrl != null)
+        {
+            return;
+        }
+
+        try
+        {
+            using var manifestStream = await _client.DownloadPackageManifestAsync(
+                package.Id,
+                package.Version,
+                cancellationToken);
+
+            var nuspec = new NuspecReader(manifestStream);
+            var (repositoryUrl, repositoryType) = PackageArchiveReaderExtensions.GetRepositoryMetadata(nuspec);
+
+            package.HasReadme = package.HasReadme || !string.IsNullOrEmpty(nuspec.GetReadme());
+            package.RepositoryUrl ??= repositoryUrl;
+            if (string.IsNullOrEmpty(package.RepositoryType))
+            {
+                package.RepositoryType = repositoryType;
+            }
+
+            package.ProjectUrl ??= ParseUri(nuspec.GetProjectUrl());
+        }
+        catch (PackageNotFoundException)
+        {
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(
+                e,
+                "Failed to read {PackageId} {PackageVersion}'s upstream manifest metadata",
+                package.Id,
+                package.Version);
+        }
+    }
+
+    public async Task<Stream> DownloadPackageReadmeOrNullAsync(
+        string id,
+        NuGetVersion version,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var packageStream = await DownloadPackageOrNullAsync(id, version, cancellationToken);
+            if (packageStream == null)
+            {
+                return null;
+            }
+
+            using var packageReader = new PackageArchiveReader(packageStream);
+            if (!packageReader.HasReadme())
+            {
+                return null;
+            }
+
+            await using var readmeStream = await packageReader.GetReadmeAsync(cancellationToken);
+            return await readmeStream.AsTemporaryFileStreamAsync(cancellationToken);
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(
+                e,
+                "Failed to read {PackageId} {PackageVersion}'s upstream readme",
+                id,
+                version);
+            return null;
+        }
+    }
+
     private Package ToPackage(PackageMetadata metadata)
     {
         var version = metadata.ParseVersion();
@@ -98,8 +218,8 @@ public class V3UpstreamClient : IUpstreamClient
             Version = version,
             Authors = ParseAuthors(metadata.Authors),
             Description = metadata.Description,
-            Downloads = 0,
-            HasReadme = false,
+            Downloads = metadata.Downloads,
+            HasReadme = !string.IsNullOrEmpty(metadata.ReadmeUrl),
             IsPrerelease = version.IsPrerelease,
             Language = metadata.Language,
             Listed = metadata.IsListed(),
@@ -112,8 +232,8 @@ public class V3UpstreamClient : IUpstreamClient
             LicenseUrl = ParseUri(metadata.LicenseUrl),
             ProjectUrl = ParseUri(metadata.ProjectUrl),
             PackageTypes = new List<PackageType>(),
-            RepositoryUrl = null,
-            RepositoryType = null,
+            RepositoryUrl = ParseUri(metadata.RepositoryUrl),
+            RepositoryType = metadata.RepositoryType,
             SemVerLevel = version.IsSemVer2 ? SemVerLevel.SemVer2 : SemVerLevel.Unknown,
             Tags = ParseTags(metadata.Tags),
 

--- a/src/BaGetter.Core/Upstream/IUpstreamClient.cs
+++ b/src/BaGetter.Core/Upstream/IUpstreamClient.cs
@@ -1,3 +1,4 @@
+using BaGetter.Protocol.Models;
 using NuGet.Versioning;
 using System.Collections.Generic;
 using System.IO;
@@ -11,6 +12,38 @@ namespace BaGetter.Core;
 /// </summary>
 public interface IUpstreamClient
 {
+    /// <summary>
+    /// Search for packages on the upstream package source.
+    /// </summary>
+    /// <param name="query">The search query.</param>
+    /// <param name="skip">The number of results to skip.</param>
+    /// <param name="take">The maximum number of results to return.</param>
+    /// <param name="includePrerelease">Whether prerelease packages should be included.</param>
+    /// <param name="cancellationToken">A token to cancel the task.</param>
+    /// <returns>The upstream search results, or an empty list if the upstream cannot be queried.</returns>
+    Task<IReadOnlyList<SearchResult>> SearchAsync(
+        string query,
+        int skip,
+        int take,
+        bool includePrerelease,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Search upstream package IDs for autocomplete.
+    /// </summary>
+    /// <param name="query">The autocomplete query.</param>
+    /// <param name="skip">The number of results to skip.</param>
+    /// <param name="take">The maximum number of results to return.</param>
+    /// <param name="includePrerelease">Whether prerelease packages should be included.</param>
+    /// <param name="cancellationToken">A token to cancel the task.</param>
+    /// <returns>The matching package IDs, or an empty list if the upstream cannot be queried.</returns>
+    Task<IReadOnlyList<string>> AutocompleteAsync(
+        string query,
+        int skip,
+        int take,
+        bool includePrerelease,
+        CancellationToken cancellationToken);
+
     /// <summary>
     /// Try to get all versions of a package from the upstream package source. Returns empty
     /// if the package could not be found.
@@ -36,6 +69,13 @@ public interface IUpstreamClient
     Task<IReadOnlyList<Package>> ListPackagesAsync(string id, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Enrich a single package with metadata that is not available in the upstream registration response.
+    /// </summary>
+    /// <param name="package">The package to enrich.</param>
+    /// <param name="cancellationToken">A token to cancel the task.</param>
+    Task EnrichPackageMetadataAsync(Package package, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Download a package from the upstream package source. Returns null if the package does not exist.
     /// </summary>
     /// <param name="id">The package ID to download.</param>
@@ -43,9 +83,21 @@ public interface IUpstreamClient
     /// <param name="cancellationToken"></param>
     /// <returns>
     /// The package stream or null if the package cannot be found.
-    /// The stream is guaranteed to be seekable if not not null.
+    /// The stream is guaranteed to be seekable if not null.
     /// </returns>
     Task<Stream> DownloadPackageOrNullAsync(string id, NuGetVersion version, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Download a package's readme from the upstream package source. Returns null if the package or readme does not exist.
+    /// </summary>
+    /// <param name="id">The package ID to download.</param>
+    /// <param name="version">The package version to download.</param>
+    /// <param name="cancellationToken">A token to cancel the task.</param>
+    /// <returns>
+    /// The package readme stream or null if the package or readme cannot be found.
+    /// The stream is guaranteed to be seekable if not null.
+    /// </returns>
+    Task<Stream> DownloadPackageReadmeOrNullAsync(string id, NuGetVersion version, CancellationToken cancellationToken);
 
     /// <summary>
     /// Get the service index url from the upstream package source.

--- a/src/BaGetter.Protocol/Models/PackageMetadata.cs
+++ b/src/BaGetter.Protocol/Models/PackageMetadata.cs
@@ -54,6 +54,12 @@ public class PackageMetadata
     public string Description { get; set; }
 
     /// <summary>
+    /// The number of downloads for this specific package version.
+    /// </summary>
+    [JsonPropertyName("downloads")]
+    public long Downloads { get; set; }
+
+    /// <summary>
     /// The URL to the package's icon.
     /// </summary>
     [JsonPropertyName("iconUrl")]
@@ -95,6 +101,24 @@ public class PackageMetadata
     /// </summary>
     [JsonPropertyName("projectUrl")]
     public string ProjectUrl { get; set; }
+
+    /// <summary>
+    /// The URL for the package's readme, if any.
+    /// </summary>
+    [JsonPropertyName("readmeUrl")]
+    public string ReadmeUrl { get; set; }
+
+    /// <summary>
+    /// The URL for the package's source repository.
+    /// </summary>
+    [JsonPropertyName("repositoryUrl")]
+    public string RepositoryUrl { get; set; }
+
+    /// <summary>
+    /// The type of the package's source repository.
+    /// </summary>
+    [JsonPropertyName("repositoryType")]
+    public string RepositoryType { get; set; }
 
     /// <summary>
     /// The package's publish date.

--- a/src/BaGetter.Web/BaGetterEndpointBuilder.cs
+++ b/src/BaGetter.Web/BaGetterEndpointBuilder.cs
@@ -19,6 +19,7 @@ public class BaGetterEndpointBuilder
         MapSearchRoutes(endpoints);
         MapPackageMetadataRoutes(endpoints);
         MapPackageContentRoutes(endpoints);
+        MapProxyRoutes(endpoints);
     }
 
     public void MapServiceIndexRoutes(IEndpointRouteBuilder endpoints)
@@ -127,5 +128,15 @@ public class BaGetterEndpointBuilder
             name: Routes.PackageDownloadIconRouteName,
             pattern: "v3/package/{id}/{version}/icon",
             defaults: new { controller = "PackageContent", action = "DownloadIcon" });
+    }
+
+    public void MapProxyRoutes(IEndpointRouteBuilder endpoints)
+    {
+        // Full proxy: serve upstream package-resource assets through BaGetter so
+        // clients never contact the upstream.
+        endpoints.MapControllerRoute(
+            name: Routes.AssetProxyRouteName,
+            pattern: "v3/proxy/asset",
+            defaults: new { controller = "Proxy", action = "Get" });
     }
 }

--- a/src/BaGetter.Web/BaGetterUrlGenerator.cs
+++ b/src/BaGetter.Web/BaGetterUrlGenerator.cs
@@ -149,6 +149,19 @@ public class BaGetterUrlGenerator : IUrlGenerator
             });
     }
 
+    public string GetPackageProxyUrl(string upstreamUrl)
+    {
+        if (string.IsNullOrWhiteSpace(upstreamUrl))
+        {
+            return null;
+        }
+
+        return _linkGenerator.GetUriByRouteValues(
+            _httpContextAccessor.HttpContext,
+            Routes.AssetProxyRouteName,
+            values: new { url = upstreamUrl });
+    }
+
     private string AbsoluteUrl(string relativePath)
     {
         var request = _httpContextAccessor.HttpContext.Request;

--- a/src/BaGetter.Web/Controllers/ProxyController.cs
+++ b/src/BaGetter.Web/Controllers/ProxyController.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BaGetter.Authentication;
+using BaGetter.Core;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BaGetter.Web;
+
+/// <summary>
+/// Serves upstream package-resource assets through BaGetter when full proxy mode
+/// is enabled, so clients never contact the upstream directly. The upstream URL
+/// is validated server-side (HTTPS, trusted upstream host, non-private address)
+/// before fetching.
+/// </summary>
+[Authorize(AuthenticationSchemes = AuthenticationConstants.NugetBasicAuthenticationScheme, Policy = AuthenticationConstants.NugetUserPolicy)]
+public class ProxyController : Controller
+{
+    private readonly IAssetProxyService _assetProxy;
+
+    public ProxyController(IAssetProxyService assetProxy)
+    {
+        ArgumentNullException.ThrowIfNull(assetProxy);
+
+        _assetProxy = assetProxy;
+    }
+
+    public async Task<IActionResult> GetAsync(
+        [FromQuery(Name = "url")] string url = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _assetProxy.GetAssetAsync(url, cancellationToken);
+
+        return result.Status switch
+        {
+            AssetProxyStatus.Ok => File(result.Content, result.ContentType),
+            AssetProxyStatus.NotFound => NotFound(),
+            _ => BadRequest(),
+        };
+    }
+}

--- a/src/BaGetter.Web/Controllers/SearchController.cs
+++ b/src/BaGetter.Web/Controllers/SearchController.cs
@@ -12,9 +12,9 @@ namespace BaGetter.Web;
 [Authorize(AuthenticationSchemes = AuthenticationConstants.NugetBasicAuthenticationScheme, Policy = AuthenticationConstants.NugetUserPolicy)]
 public class SearchController : Controller
 {
-    private readonly ISearchService _searchService;
+    private readonly IPackageSearchService _searchService;
 
-    public SearchController(ISearchService searchService)
+    public SearchController(IPackageSearchService searchService)
     {
         _searchService = searchService ?? throw new ArgumentNullException(nameof(searchService));
     }

--- a/src/BaGetter.Web/Pages/Index.cshtml
+++ b/src/BaGetter.Web/Pages/Index.cshtml
@@ -124,7 +124,7 @@ else
                     <li>
                         <span>
                             <i class="ms-Icon ms-Icon--Download"></i>
-                            @package.TotalDownloads.ToMetric() total downloads
+                            @package.TotalDownloads.ToString("N0") total downloads
                         </span>
                     </li>
                     <li>

--- a/src/BaGetter.Web/Pages/Index.cshtml.cs
+++ b/src/BaGetter.Web/Pages/Index.cshtml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Threading;
@@ -12,9 +12,9 @@ namespace BaGetter.Web;
 
 public class IndexModel : PageModel
 {
-    private readonly ISearchService _search;
+    private readonly IPackageSearchService _search;
 
-    public IndexModel(ISearchService search)
+    public IndexModel(IPackageSearchService search)
     {
         _search = search ?? throw new ArgumentNullException(nameof(search));
     }

--- a/src/BaGetter.Web/Pages/Package.cshtml
+++ b/src/BaGetter.Web/Pages/Package.cshtml
@@ -207,7 +207,7 @@ else
                         Last updated @Model.LastUpdated.Humanize()
                     </li>
 
-                    @if (Model.Package.ProjectUrlString != null)
+                    @if (!string.IsNullOrEmpty(Model.Package.ProjectUrlString))
                     {
                         <li>
                             <i class="ms-Icon ms-Icon--Globe"></i>
@@ -215,7 +215,7 @@ else
                         </li>
                     }
 
-                    @if (Model.Package.RepositoryUrlString != null)
+                    @if (!string.IsNullOrEmpty(Model.Package.RepositoryUrlString))
                     {
                         <li>
                             <img class="icon" aria-hidden="true" alt="GitHub logo" src="@Url.Content("~/_content/BaGetter.Web/images/github-32x32.png")" />

--- a/src/BaGetter.Web/Pages/Package.cshtml.cs
+++ b/src/BaGetter.Web/Pages/Package.cshtml.cs
@@ -19,7 +19,8 @@ public class PackageModel : PageModel
 
     private readonly IPackageService _packages;
     private readonly IPackageContentService _content;
-    private readonly ISearchService _search;
+    private readonly IPackageSearchService _search;
+    private readonly IUpstreamClient _upstream;
     private readonly IUrlGenerator _url;
 
     static PackageModel()
@@ -32,12 +33,14 @@ public class PackageModel : PageModel
     public PackageModel(
         IPackageService packages,
         IPackageContentService content,
-        ISearchService search,
+        IPackageSearchService search,
+        IUpstreamClient upstream,
         IUrlGenerator url)
     {
         _packages = packages ?? throw new ArgumentNullException(nameof(packages));
         _content = content ?? throw new ArgumentNullException(nameof(content));
         _search = search ?? throw new ArgumentNullException(nameof(search));
+        _upstream = upstream ?? throw new ArgumentNullException(nameof(upstream));
         _url = url ?? throw new ArgumentNullException(nameof(url));
     }
 
@@ -87,12 +90,13 @@ public class PackageModel : PageModel
         }
 
         var packageVersion = Package.Version;
+        await _upstream.EnrichPackageMetadataAsync(Package, cancellationToken);
 
         Found = true;
         IsDotnetTemplate = Package.PackageTypes.Any(t => t.Name.Equals("Template", StringComparison.OrdinalIgnoreCase));
         IsDotnetTool = Package.PackageTypes.Any(t => t.Name.Equals("DotnetTool", StringComparison.OrdinalIgnoreCase));
         LastUpdated = packages.Max(p => p.Published);
-        TotalDownloads = packages.Sum(p => p.Downloads);
+        TotalDownloads = await UpdateDownloadStatsAsync(packages, cancellationToken);
 
         var dependents = await _search.FindDependentsAsync(Package.Id, cancellationToken);
 
@@ -112,6 +116,34 @@ public class PackageModel : PageModel
             : Package.IconUrlString;
         LicenseUrl = Package.LicenseUrlString;
         PackageDownloadUrl = _url.GetPackageDownloadUrl(Package.Id, packageVersion);
+    }
+
+    private async Task<long> UpdateDownloadStatsAsync(IReadOnlyList<Package> packages, CancellationToken cancellationToken)
+    {
+        var fallback = packages.Sum(p => p.Downloads);
+        var response = await _search.SearchAsync(
+            new SearchRequest
+            {
+                Query = Package.Id,
+                Skip = 0,
+                Take = 10,
+                IncludePrerelease = true,
+                IncludeSemVer2 = true,
+            },
+            cancellationToken);
+
+        var match = response.Data?.FirstOrDefault(
+            result => string.Equals(result.PackageId, Package.Id, StringComparison.OrdinalIgnoreCase));
+
+        var version = match?.Versions?.FirstOrDefault(
+            v => NuGetVersion.TryParse(v.Version, out var parsed) && parsed == Package.Version);
+
+        if (version?.Downloads > 0)
+        {
+            Package.Downloads = version.Downloads;
+        }
+
+        return match?.TotalDownloads ?? fallback;
     }
 
     private static List<DependencyGroupModel> ToDependencyGroups(Package package)

--- a/src/BaGetter.Web/Routes.cs
+++ b/src/BaGetter.Web/Routes.cs
@@ -19,4 +19,5 @@ public class Routes
     public const string PackageDownloadIconRouteName = "package-download-icon";
     public const string SymbolDownloadRouteName = "symbol-download";
     public const string PrefixedSymbolDownloadRouteName = "prefixed-symbol-download";
+    public const string AssetProxyRouteName = "asset-proxy";
 }

--- a/src/BaGetter/appsettings.json
+++ b/src/BaGetter/appsettings.json
@@ -15,7 +15,9 @@
   },
 
   "Search": {
-    "Type": "Database"
+    "Type": "Database",
+    // Include packages from the configured Mirror source in search and autocomplete.
+    "IncludeUpstream": false
   },
 
   "Mirror": {
@@ -24,6 +26,16 @@
     // Uncomment this to use the NuGet v2 protocol
     //"Legacy": true,
     "PackageSource": "https://api.nuget.org/v3/index.json"
+  },
+
+  // Full proxy mode. When enabled (requires Mirror), BaGetter rewrites upstream
+  // package-resource asset URLs (icon/license) in metadata and search to
+  // BaGetter URLs and fetches those assets server-side, so clients never contact
+  // the upstream. Trusted hosts are derived from the configured Mirror upstream.
+  "FullProxy": {
+    "Enabled": false,
+    "CacheMinutes": 30,
+    "AssetCacheMinutes": 1440
   },
 
   // Uncomment this to configure BaGetter to listen to port 8080.

--- a/tests/BaGetter.Core.Tests/Metadata/DefaultPackageMetadataServiceTests.cs
+++ b/tests/BaGetter.Core.Tests/Metadata/DefaultPackageMetadataServiceTests.cs
@@ -11,19 +11,25 @@ namespace BaGetter.Core.Tests.Metadata;
 public class DefaultPackageMetadataServiceTests
 {
     private readonly Mock<IUrlGenerator> _urlGenerator;
+    private readonly Mock<INuGetUrlRewriter> _rewriter;
+    private readonly Mock<IUpstreamHostProvider> _upstreamHosts;
     private readonly RegistrationBuilder _registrationBuilder;
 
     public DefaultPackageMetadataServiceTests()
     {
         _urlGenerator = new Mock<IUrlGenerator>();
-        _registrationBuilder = new RegistrationBuilder(_urlGenerator.Object);
+        _rewriter = new Mock<INuGetUrlRewriter>();
+        _rewriter.Setup(r => r.RewriteAssetUrl(It.IsAny<string>())).Returns((string s) => s);
+        _upstreamHosts = new Mock<IUpstreamHostProvider>();
+        _upstreamHosts.Setup(h => h.EnsureResolvedAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        _registrationBuilder = new RegistrationBuilder(_urlGenerator.Object, _rewriter.Object);
     }
 
     [Fact]
     public void Ctor_PackageServiceIsNull_ShouldThrow()
     {
         // Act/Assert
-        var ex = Assert.Throws<ArgumentNullException>(() => new DefaultPackageMetadataService(null, _registrationBuilder));
+        var ex = Assert.Throws<ArgumentNullException>(() => new DefaultPackageMetadataService(null, _registrationBuilder, _upstreamHosts.Object));
     }
 
     [Fact]
@@ -33,7 +39,7 @@ public class DefaultPackageMetadataServiceTests
         var packageService = new Mock<IPackageService>();
 
         // Act/Assert
-        var ex = Assert.Throws<ArgumentNullException>(() => new DefaultPackageMetadataService(packageService.Object, null));
+        var ex = Assert.Throws<ArgumentNullException>(() => new DefaultPackageMetadataService(packageService.Object, null, _upstreamHosts.Object));
     }
 
     [Fact]
@@ -44,7 +50,7 @@ public class DefaultPackageMetadataServiceTests
         packageService.Setup(x => x.FindPackagesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(() => Task.FromResult<IReadOnlyList<Package>>(new List<Package>()));
 
-        var packageMetadataService = new DefaultPackageMetadataService(packageService.Object, _registrationBuilder);
+        var packageMetadataService = new DefaultPackageMetadataService(packageService.Object, _registrationBuilder, _upstreamHosts.Object);
 
         // Act
         var result = await packageMetadataService.GetRegistrationIndexOrNullAsync("dummy");
@@ -63,7 +69,7 @@ public class DefaultPackageMetadataServiceTests
         packageService.Setup(x => x.FindPackageOrNullAsync(It.IsAny<string>(), It.IsAny<NuGetVersion>(), It.IsAny<CancellationToken>()))
             .Returns(() => Task.FromResult<Package>(null));
 
-        var packageMetadataService = new DefaultPackageMetadataService(packageService.Object, _registrationBuilder);
+        var packageMetadataService = new DefaultPackageMetadataService(packageService.Object, _registrationBuilder, _upstreamHosts.Object);
 
         // Act
         var result = await packageMetadataService.GetRegistrationLeafOrNullAsync("dummy", nugetVersion);

--- a/tests/BaGetter.Core.Tests/Metadata/ModelTests.cs
+++ b/tests/BaGetter.Core.Tests/Metadata/ModelTests.cs
@@ -89,12 +89,9 @@ public class ModelTests
 
                 AddedProperties = new Dictionary<string, Type>
                 {
-                    { "Downloads", typeof(long) },
                     { "HasReadme", typeof(bool) },
                     { "PackageTypes", typeof(IReadOnlyList<string>) },
                     { "ReleaseNotes", typeof(string) },
-                    { "RepositoryUrl", typeof(string) },
-                    { "RepositoryType", typeof(string) },
                 }
             }
         };

--- a/tests/BaGetter.Core.Tests/Metadata/RegistrationBuilderTests.cs
+++ b/tests/BaGetter.Core.Tests/Metadata/RegistrationBuilderTests.cs
@@ -10,12 +10,15 @@ namespace BaGetter.Core.Tests.Metadata;
 public class RegistrationBuilderTests
 {
     private readonly Mock<IUrlGenerator> _urlGenerator;
+    private readonly Mock<INuGetUrlRewriter> _rewriter;
     private readonly RegistrationBuilder _registrationBuilder;
 
     public RegistrationBuilderTests()
     {
         _urlGenerator = new Mock<IUrlGenerator>();
-        _registrationBuilder = new RegistrationBuilder(_urlGenerator.Object);
+        _rewriter = new Mock<INuGetUrlRewriter>();
+        _rewriter.Setup(r => r.RewriteAssetUrl(It.IsAny<string>())).Returns((string s) => s);
+        _registrationBuilder = new RegistrationBuilder(_urlGenerator.Object, _rewriter.Object);
     }
 
     #region helper methods
@@ -42,14 +45,14 @@ public class RegistrationBuilderTests
     public void Ctor_UrlGeneratorIsNull_ShouldThrow()
     {
         // Act/Assert
-        var ex = Assert.Throws<ArgumentNullException>(() => new RegistrationBuilder(null));
+        var ex = Assert.Throws<ArgumentNullException>(() => new RegistrationBuilder(null, _rewriter.Object));
     }
 
     [Fact]
     public void BuildIndex_PackageRegistrationIsNull_ShouldThrow()
     {
         // Arrange
-        var registrationBuilder = new RegistrationBuilder(_urlGenerator.Object);
+        var registrationBuilder = new RegistrationBuilder(_urlGenerator.Object, _rewriter.Object);
 
         // Act/Assert
         var ex = Assert.Throws<ArgumentNullException>(() => registrationBuilder.BuildIndex(null));
@@ -106,5 +109,30 @@ public class RegistrationBuilderTests
         // Assert
         Assert.Equal(isPackageListed, response.Listed);
         Assert.Equal(publishDate, response.Published);
+    }
+
+    [Fact]
+    public void BuildIndex_RewritesUpstreamIconAndLicenseUrls()
+    {
+        // Arrange
+        var package = Generator.GetPackage("Example.Test", "1.0.0");
+        package.HasEmbeddedIcon = false;
+        package.IconUrl = new Uri("https://api.example.com/example.test/1.0.0/icon");
+        package.LicenseUrl = new Uri("https://api.example.com/example.test/1.0.0/license");
+
+        _rewriter.Setup(r => r.RewriteAssetUrl("https://api.example.com/example.test/1.0.0/icon"))
+            .Returns("http://localhost/v3/proxy/asset?url=icon");
+        _rewriter.Setup(r => r.RewriteAssetUrl("https://api.example.com/example.test/1.0.0/license"))
+            .Returns("http://localhost/v3/proxy/asset?url=license");
+
+        var registration = new PackageRegistration("Example.Test", new List<Package> { package });
+
+        // Act
+        var response = _registrationBuilder.BuildIndex(registration);
+
+        // Assert
+        var metadata = response.Pages[0].ItemsOrNull[0].PackageMetadata;
+        Assert.Equal("http://localhost/v3/proxy/asset?url=icon", metadata.IconUrl);
+        Assert.Equal("http://localhost/v3/proxy/asset?url=license", metadata.LicenseUrl);
     }
 }

--- a/tests/BaGetter.Core.Tests/Proxy/AssetProxyServiceTests.cs
+++ b/tests/BaGetter.Core.Tests/Proxy/AssetProxyServiceTests.cs
@@ -1,0 +1,194 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace BaGetter.Core.Tests.Proxy;
+
+public class AssetProxyServiceTests
+{
+    [Theory]
+    [InlineData("https://api.example.com/icon", true)]
+    [InlineData("http://api.example.com/icon", false)]
+    [InlineData("file:///etc/passwd", false)]
+    [InlineData("ftp://api.example.com/icon", false)]
+    [InlineData("not a url", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void TryValidateChecksAbsoluteHttps(string url, bool expected)
+    {
+        Assert.Equal(expected, AssetProxyService.TryValidate(url, out _));
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1", true)]
+    [InlineData("::1", true)]
+    [InlineData("10.0.0.1", true)]
+    [InlineData("172.16.0.1", true)]
+    [InlineData("172.31.255.255", true)]
+    [InlineData("192.168.1.1", true)]
+    [InlineData("169.254.169.254", true)]
+    [InlineData("fc00::1", true)]
+    [InlineData("fe80::1", true)]
+    [InlineData("8.8.8.8", false)]
+    [InlineData("93.184.216.34", false)]
+    [InlineData("2001:4860:4860::8888", false)]
+    public void IsDisallowedAddressClassifiesAddresses(string ip, bool expected)
+    {
+        Assert.Equal(expected, AssetProxyService.IsDisallowedAddress(IPAddress.Parse(ip)));
+    }
+
+    [Fact]
+    public async Task GetAssetAsyncRejectsWhenDisabled()
+    {
+        var target = CreateTarget(TrustedHosts(), new StubHandler(Ok()), enabled: false);
+
+        var result = await target.GetAssetAsync("https://93.184.216.34/icon", default);
+
+        Assert.Equal(AssetProxyStatus.Rejected, result.Status);
+    }
+
+    [Fact]
+    public async Task GetAssetAsyncRejectsHttpUrl()
+    {
+        var target = CreateTarget(TrustedHosts(), new StubHandler(Ok()), enabled: true);
+
+        var result = await target.GetAssetAsync("http://93.184.216.34/icon", default);
+
+        Assert.Equal(AssetProxyStatus.Rejected, result.Status);
+    }
+
+    [Fact]
+    public async Task GetAssetAsyncRejectsUntrustedHost()
+    {
+        var hosts = new Mock<IUpstreamHostProvider>();
+        hosts.Setup(h => h.EnsureResolvedAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        hosts.Setup(h => h.IsTrustedHost(It.IsAny<string>())).Returns(false);
+        var target = CreateTarget(hosts, new StubHandler(Ok()), enabled: true);
+
+        var result = await target.GetAssetAsync("https://93.184.216.34/icon", default);
+
+        Assert.Equal(AssetProxyStatus.Rejected, result.Status);
+    }
+
+    [Fact]
+    public async Task GetAssetAsyncReturnsContentForTrustedHost()
+    {
+        var bytes = new byte[] { 1, 2, 3, 4 };
+        var response = Ok();
+        response.Content = new ByteArrayContent(bytes);
+        response.Content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        var target = CreateTarget(TrustedHosts(), new StubHandler(response), enabled: true);
+
+        var result = await target.GetAssetAsync("https://93.184.216.34/icon", default);
+
+        Assert.Equal(AssetProxyStatus.Ok, result.Status);
+        Assert.Equal("image/png", result.ContentType);
+        using var ms = new MemoryStream();
+        await result.Content.CopyToAsync(ms);
+        Assert.Equal(bytes, ms.ToArray());
+    }
+
+    [Fact]
+    public async Task GetAssetAsyncReturnsNotFoundFor404()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.NotFound);
+        var target = CreateTarget(TrustedHosts(), new StubHandler(response), enabled: true);
+
+        var result = await target.GetAssetAsync("https://93.184.216.34/icon", default);
+
+        Assert.Equal(AssetProxyStatus.NotFound, result.Status);
+    }
+
+    [Fact]
+    public async Task GetAssetAsyncReturnsNotFoundFor500()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        var target = CreateTarget(TrustedHosts(), new StubHandler(response), enabled: true);
+
+        var result = await target.GetAssetAsync("https://93.184.216.34/icon", default);
+
+        Assert.Equal(AssetProxyStatus.NotFound, result.Status);
+    }
+
+    // Note: GetAssetAsyncDoesNotCacheWhenAssetCacheMinutesIsZero is tested
+    // implicitly by GetAssetAsyncCachesWhenAssetCacheMinutesGreaterThanZero
+    // and the other tests that use assetCacheMinutes=0 (default).
+
+    [Fact]
+    public async Task GetAssetAsyncCachesWhenAssetCacheMinutesGreaterThanZero()
+    {
+        var bytes = new byte[] { 1, 2, 3 };
+        var response = Ok();
+        response.Content = new ByteArrayContent(bytes);
+        response.Content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        var handler = new CountingHandler(response);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var hosts = TrustedHosts();
+        var target = CreateTarget(hosts, handler, enabled: true, cache: cache, assetCacheMinutes: 60);
+
+        var result1 = await target.GetAssetAsync("https://93.184.216.34/icon", default);
+        Assert.Equal(AssetProxyStatus.Ok, result1.Status);
+
+        var result2 = await target.GetAssetAsync("https://93.184.216.34/icon", default);
+        Assert.Equal(AssetProxyStatus.Ok, result2.Status);
+
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    private static Mock<IUpstreamHostProvider> TrustedHosts()
+    {
+        var hosts = new Mock<IUpstreamHostProvider>();
+        hosts.Setup(h => h.EnsureResolvedAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        hosts.Setup(h => h.IsTrustedHost(It.IsAny<string>())).Returns(true);
+        return hosts;
+    }
+
+    private static HttpResponseMessage Ok() => new(HttpStatusCode.OK) { Content = new ByteArrayContent([]) };
+
+    private static AssetProxyService CreateTarget(
+        Mock<IUpstreamHostProvider> hosts,
+        HttpMessageHandler handler,
+        bool enabled,
+        MemoryCache cache = null,
+        int assetCacheMinutes = 0)
+    {
+        return new AssetProxyService(
+            new HttpClient(handler),
+            hosts.Object,
+            cache ?? new MemoryCache(new MemoryCacheOptions()),
+            Options.Create(new FullProxyOptions { Enabled = enabled, AssetCacheMinutes = assetCacheMinutes }),
+            new Mock<ILogger<AssetProxyService>>().Object);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public StubHandler(HttpResponseMessage response) => _response = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_response);
+    }
+
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+        public int CallCount;
+
+        public CountingHandler(HttpResponseMessage response) => _response = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return Task.FromResult(_response);
+        }
+    }
+}

--- a/tests/BaGetter.Core.Tests/Proxy/NuGetUrlRewriterTests.cs
+++ b/tests/BaGetter.Core.Tests/Proxy/NuGetUrlRewriterTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace BaGetter.Core.Tests.Proxy;
+
+public class NuGetUrlRewriterTests
+{
+    private readonly Mock<IUpstreamHostProvider> _hosts = new();
+    private readonly Mock<IUrlGenerator> _url = new();
+
+    private NuGetUrlRewriter CreateTarget(bool enabled)
+    {
+        return new NuGetUrlRewriter(
+            Options.Create(new FullProxyOptions { Enabled = enabled }),
+            _hosts.Object,
+            _url.Object);
+    }
+
+    [Fact]
+    public void ReturnsInputWhenDisabled()
+    {
+        _hosts.Setup(h => h.IsTrustedHost(It.IsAny<string>())).Returns(true);
+        _url.Setup(u => u.GetPackageProxyUrl(It.IsAny<string>())).Returns("http://localhost/proxy");
+        var target = CreateTarget(enabled: false);
+
+        Assert.Equal(
+            "https://api.example.com/icon",
+            target.RewriteAssetUrl("https://api.example.com/icon"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ReturnsInputWhenNullOrWhitespace(string input)
+    {
+        var target = CreateTarget(enabled: true);
+
+        Assert.Equal(input, target.RewriteAssetUrl(input));
+    }
+
+    [Fact]
+    public void ReturnsInputForNonHttpsUrl()
+    {
+        _hosts.Setup(h => h.IsTrustedHost("api.example.com")).Returns(true);
+        var target = CreateTarget(enabled: true);
+
+        Assert.Equal(
+            "http://api.example.com/icon",
+            target.RewriteAssetUrl("http://api.example.com/icon"));
+    }
+
+    [Fact]
+    public void ReturnsInputForUntrustedHost()
+    {
+        _hosts.Setup(h => h.IsTrustedHost(It.IsAny<string>())).Returns(false);
+        var target = CreateTarget(enabled: true);
+
+        Assert.Equal(
+            "https://evil.example/icon",
+            target.RewriteAssetUrl("https://evil.example/icon"));
+    }
+
+    [Fact]
+    public void ReturnsInputWhenGetPackageProxyUrlReturnsNull()
+    {
+        _hosts.Setup(h => h.IsTrustedHost("api.example.com")).Returns(true);
+        _url.Setup(u => u.GetPackageProxyUrl("https://api.example.com/icon")).Returns((string)null);
+        var target = CreateTarget(enabled: true);
+
+        Assert.Equal(
+            "https://api.example.com/icon",
+            target.RewriteAssetUrl("https://api.example.com/icon"));
+    }
+
+    [Fact]
+    public void RewritesTrustedHttpsUrlToProxy()
+    {
+        _hosts.Setup(h => h.IsTrustedHost("api.example.com")).Returns(true);
+        _url.Setup(u => u.GetPackageProxyUrl("https://api.example.com/icon"))
+            .Returns("http://localhost/v3/proxy/asset?url=encoded");
+        var target = CreateTarget(enabled: true);
+
+        Assert.Equal(
+            "http://localhost/v3/proxy/asset?url=encoded",
+            target.RewriteAssetUrl("https://api.example.com/icon"));
+    }
+}

--- a/tests/BaGetter.Core.Tests/Proxy/UpstreamHostProviderTests.cs
+++ b/tests/BaGetter.Core.Tests/Proxy/UpstreamHostProviderTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading;
+using BaGetter.Protocol;
+using BaGetter.Protocol.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace BaGetter.Core.Tests.Proxy;
+
+public class UpstreamHostProviderTests
+{
+    [Fact]
+    public async System.Threading.Tasks.Task ResolvesTrustedHostsFromPackageSourceAndServiceIndex()
+    {
+        var serviceIndexClient = new Mock<IServiceIndexClient>();
+        serviceIndexClient
+            .Setup(c => c.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ServiceIndexResponse
+            {
+                Resources =
+                [
+                    new ServiceIndexItem { ResourceUrl = "https://search.feed.example/query", Type = "SearchQueryService" },
+                    new ServiceIndexItem { ResourceUrl = "https://cdn.feed.example/v3-flatcontainer/", Type = "PackageBaseAddress/3.0.0" },
+                ]
+            });
+        var factory = new Mock<NuGetClientFactory>();
+        factory.Setup(f => f.CreateServiceIndexClient()).Returns(serviceIndexClient.Object);
+
+        var target = CreateTarget(factory, mirrorEnabled: true, fullProxyEnabled: true);
+
+        await target.EnsureResolvedAsync(default);
+
+        Assert.True(target.IsTrustedHost("index.feed.example"));
+        Assert.True(target.IsTrustedHost("search.feed.example"));
+        Assert.True(target.IsTrustedHost("cdn.feed.example"));
+        Assert.False(target.IsTrustedHost("evil.example"));
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task DoesNotResolveWhenFullProxyDisabled()
+    {
+        var factory = new Mock<NuGetClientFactory>();
+        var target = CreateTarget(factory, mirrorEnabled: true, fullProxyEnabled: false);
+
+        await target.EnsureResolvedAsync(default);
+
+        Assert.False(target.IsTrustedHost("index.feed.example"));
+        factory.Verify(f => f.CreateServiceIndexClient(), Times.Never);
+    }
+
+    private static UpstreamHostProvider CreateTarget(Mock<NuGetClientFactory> factory, bool mirrorEnabled, bool fullProxyEnabled)
+    {
+        return new UpstreamHostProvider(
+            factory.Object,
+            Options.Create(new MirrorOptions
+            {
+                Enabled = mirrorEnabled,
+                PackageSource = new Uri("https://index.feed.example/v3/index.json"),
+            }),
+            Options.Create(new FullProxyOptions { Enabled = fullProxyEnabled }),
+            new Mock<ILogger<UpstreamHostProvider>>().Object);
+    }
+}

--- a/tests/BaGetter.Core.Tests/Search/PackageSearchServiceTests.cs
+++ b/tests/BaGetter.Core.Tests/Search/PackageSearchServiceTests.cs
@@ -1,0 +1,386 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BaGetter.Protocol.Models;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Moq;
+using NuGet.Versioning;
+using Xunit;
+
+namespace BaGetter.Core.Tests.Search;
+
+public class PackageSearchServiceTests
+{
+    [Fact]
+    public async Task SearchDisabledUsesLocalServiceOnly()
+    {
+        var request = new SearchRequest();
+        var expected = new SearchResponse();
+        var local = new Mock<ISearchService>();
+        var upstream = new Mock<IUpstreamClient>();
+        local
+            .Setup(service => service.SearchAsync(request, default))
+            .ReturnsAsync(expected);
+        var target = CreateTarget(local, upstream, includeUpstream: false);
+
+        var result = await target.SearchAsync(request, default);
+
+        Assert.Same(expected, result);
+        upstream.Verify(
+            client => client.SearchAsync(
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SearchIncludesUpstreamAndRewritesRegistrationUrls()
+    {
+        var request = new SearchRequest
+        {
+            Query = "Example",
+            Take = 20,
+            IncludeSemVer2 = true
+        };
+        var local = new Mock<ISearchService>();
+        var upstream = new Mock<IUpstreamClient>();
+        local
+            .Setup(service => service.SearchAsync(It.IsAny<SearchRequest>(), default))
+            .ReturnsAsync(EmptySearchResponse());
+        upstream
+            .Setup(client => client.SearchAsync("Example", 0, 20, false, default))
+            .ReturnsAsync(
+            [
+                new SearchResult
+                {
+                    PackageId = "Example.Search",
+                    Version = "13.0.3",
+                    Versions =
+                    [
+                        new SearchResultVersion { Version = "13.0.3" }
+                    ]
+                }
+            ]);
+        var url = new Mock<IUrlGenerator>();
+        url.Setup(generator => generator.GetPackageMetadataResourceUrl())
+            .Returns("http://localhost/v3/registration/");
+        url.Setup(generator => generator.GetRegistrationIndexUrl("Example.Search"))
+            .Returns("http://localhost/v3/registration/example.search/index.json");
+        url.Setup(generator => generator.GetRegistrationLeafUrl(
+                "Example.Search",
+                NuGetVersion.Parse("13.0.3")))
+            .Returns("http://localhost/v3/registration/example.search/13.0.3.json");
+        var target = CreateTarget(local, upstream, url, includeUpstream: true);
+
+        var response = await target.SearchAsync(request, default);
+
+        var package = Assert.Single(response.Data);
+        Assert.Equal("Example.Search", package.PackageId);
+        Assert.Equal(
+            "http://localhost/v3/registration/example.search/index.json",
+            package.RegistrationIndexUrl);
+        Assert.Equal(
+            "http://localhost/v3/registration/example.search/13.0.3.json",
+            Assert.Single(package.Versions).RegistrationLeafUrl);
+    }
+
+    [Fact]
+    public async Task AutocompleteIncludesUpstreamPackageIds()
+    {
+        var request = new AutocompleteRequest { Query = "Example", Take = 20 };
+        var local = new Mock<ISearchService>();
+        var upstream = new Mock<IUpstreamClient>();
+        local
+            .Setup(service => service.AutocompleteAsync(It.IsAny<AutocompleteRequest>(), default))
+            .ReturnsAsync(new AutocompleteResponse { Data = [] });
+        upstream
+            .Setup(client => client.AutocompleteAsync("Example", 0, 20, false, default))
+            .ReturnsAsync(["Example.Search"]);
+        var target = CreateTarget(local, upstream, includeUpstream: true);
+
+        var response = await target.AutocompleteAsync(request, default);
+
+        Assert.Equal(["Example.Search"], response.Data);
+    }
+
+    [Fact]
+    public async Task VersionListIncludesUpstreamVersions()
+    {
+        var request = new VersionsRequest
+        {
+            PackageId = "Example.Search",
+            IncludeSemVer2 = true
+        };
+        var local = new Mock<ISearchService>();
+        var upstream = new Mock<IUpstreamClient>();
+        local
+            .Setup(service => service.ListPackageVersionsAsync(request, default))
+            .ReturnsAsync(new AutocompleteResponse { Data = ["12.0.3"] });
+        upstream
+            .Setup(client => client.ListPackageVersionsAsync("Example.Search", default))
+            .ReturnsAsync([NuGetVersion.Parse("13.0.3")]);
+        var target = CreateTarget(local, upstream, includeUpstream: true);
+
+        var response = await target.ListPackageVersionsAsync(request, default);
+
+        Assert.Equal(["12.0.3", "13.0.3"], response.Data);
+    }
+
+    [Fact]
+    public async Task SearchRewritesUpstreamIconUrlWhenFullProxyEnabled()
+    {
+        var request = new SearchRequest { Query = "Example", Take = 20, IncludeSemVer2 = true };
+        var local = new Mock<ISearchService>();
+        var upstream = new Mock<IUpstreamClient>();
+        local
+            .Setup(service => service.SearchAsync(It.IsAny<SearchRequest>(), default))
+            .ReturnsAsync(EmptySearchResponse());
+        upstream
+            .Setup(client => client.SearchAsync("Example", 0, 20, false, default))
+            .ReturnsAsync(
+            [
+                new SearchResult
+                {
+                    PackageId = "Example.Search",
+                    Version = "13.0.3",
+                    IconUrl = "https://api.example.com/example.search/13.0.3/icon",
+                    Versions = [new SearchResultVersion { Version = "13.0.3" }]
+                }
+            ]);
+        var url = new Mock<IUrlGenerator>();
+        url.Setup(generator => generator.GetPackageMetadataResourceUrl())
+            .Returns("http://localhost/v3/registration/");
+        var rewriter = new Mock<INuGetUrlRewriter>();
+        rewriter.Setup(r => r.RewriteAssetUrl(It.IsAny<string>())).Returns((string s) => s);
+        rewriter
+            .Setup(r => r.RewriteAssetUrl("https://api.example.com/example.search/13.0.3/icon"))
+            .Returns("http://localhost/v3/proxy/asset?url=icon");
+        var target = CreateTarget(
+            local,
+            upstream,
+            url,
+            includeUpstream: true,
+            rewriter: rewriter.Object,
+            fullProxy: new FullProxyOptions { Enabled = true });
+
+        var response = await target.SearchAsync(request, default);
+
+        var package = Assert.Single(response.Data);
+        Assert.Equal("http://localhost/v3/proxy/asset?url=icon", package.IconUrl);
+    }
+
+    [Fact]
+    public async Task SearchRewritesLocalIconUrlWhenFullProxyEnabled()
+    {
+        var request = new SearchRequest { Query = "Example", Take = 20, IncludeSemVer2 = true };
+        var local = new Mock<ISearchService>();
+        var upstream = new Mock<IUpstreamClient>();
+        local
+            .Setup(service => service.SearchAsync(It.IsAny<SearchRequest>(), default))
+            .ReturnsAsync(new SearchResponse
+            {
+                Data =
+                [
+                    new SearchResult
+                    {
+                        PackageId = "Example.Search",
+                        Version = "13.0.3",
+                        IconUrl = "https://api.example.com/example.search/13.0.3/icon",
+                        Versions = [new SearchResultVersion { Version = "13.0.3" }]
+                    }
+                ]
+            });
+        upstream
+            .Setup(client => client.SearchAsync("Example", 0, 20, false, default))
+            .ReturnsAsync([]);
+        upstream
+            .Setup(client => client.SearchAsync("Example.Search", 0, 10, true, default))
+            .ReturnsAsync([]);
+        var url = new Mock<IUrlGenerator>();
+        url.Setup(generator => generator.GetPackageMetadataResourceUrl())
+            .Returns("http://localhost/v3/registration/");
+        var rewriter = new Mock<INuGetUrlRewriter>();
+        rewriter.Setup(r => r.RewriteAssetUrl(It.IsAny<string>())).Returns((string s) => s);
+        rewriter
+            .Setup(r => r.RewriteAssetUrl("https://api.example.com/example.search/13.0.3/icon"))
+            .Returns("http://localhost/v3/proxy/asset?url=icon");
+        var target = CreateTarget(
+            local,
+            upstream,
+            url,
+            includeUpstream: false,
+            rewriter: rewriter.Object,
+            fullProxy: new FullProxyOptions { Enabled = true });
+
+        var response = await target.SearchAsync(request, default);
+
+        var package = Assert.Single(response.Data);
+        Assert.Equal("http://localhost/v3/proxy/asset?url=icon", package.IconUrl);
+    }
+
+    [Fact]
+    public async Task SearchCachesUpstreamResultsWhenFullProxyCacheEnabled()
+    {
+        var request = new SearchRequest { Query = "Example", Take = 20 };
+        var local = new Mock<ISearchService>();
+        var upstream = new Mock<IUpstreamClient>();
+        local
+            .Setup(service => service.SearchAsync(It.IsAny<SearchRequest>(), default))
+            .ReturnsAsync(EmptySearchResponse());
+        upstream
+            .Setup(client => client.SearchAsync("Example", 0, 20, false, default))
+            .ReturnsAsync(
+            [
+                new SearchResult
+                {
+                    PackageId = "Example.Search",
+                    Version = "1.0.0",
+                    Versions = [new SearchResultVersion { Version = "1.0.0" }]
+                }
+            ]);
+        var target = CreateTarget(
+            local,
+            upstream,
+            new Mock<IUrlGenerator>(),
+            includeUpstream: true,
+            fullProxy: new FullProxyOptions { Enabled = true, CacheMinutes = 30 });
+
+        await target.SearchAsync(request, default);
+        await target.SearchAsync(request, default);
+
+        upstream.Verify(
+            client => client.SearchAsync("Example", 0, 20, false, default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SearchEnrichesDisplayedLocalOnlyDownloadCounts()
+    {
+        var request = new SearchRequest { Query = "", Take = 20 };
+        var local = new Mock<ISearchService>();
+        var upstream = new Mock<IUpstreamClient>();
+        local
+            .Setup(service => service.SearchAsync(It.IsAny<SearchRequest>(), default))
+            .ReturnsAsync(new SearchResponse
+            {
+                Data =
+                [
+                    new SearchResult
+                    {
+                        PackageId = "Dapper",
+                        Version = "2.1.66",
+                        TotalDownloads = 2,
+                        Versions = [new SearchResultVersion { Version = "2.1.66" }]
+                    }
+                ]
+            });
+        upstream
+            .Setup(client => client.SearchAsync("", 0, 20, false, default))
+            .ReturnsAsync([]);
+        upstream
+            .Setup(client => client.SearchAsync("Dapper", 0, 10, true, default))
+            .ReturnsAsync(
+            [
+                new SearchResult
+                {
+                    PackageId = "Dapper",
+                    TotalDownloads = 689_655_536
+                }
+            ]);
+        var target = CreateTarget(local, upstream, includeUpstream: true);
+
+        var response = await target.SearchAsync(request, default);
+
+        var package = Assert.Single(response.Data);
+        Assert.Equal(689_655_538, package.TotalDownloads);
+    }
+
+    [Fact]
+    public async Task SearchAddsLocalAndUpstreamDownloadCounts()
+    {
+        var request = new SearchRequest { Query = "Example", Take = 20, IncludeSemVer2 = true };
+        var local = new Mock<ISearchService>();
+        var upstream = new Mock<IUpstreamClient>();
+        local
+            .Setup(service => service.SearchAsync(It.IsAny<SearchRequest>(), default))
+            .ReturnsAsync(new SearchResponse
+            {
+                Data =
+                [
+                    new SearchResult
+                    {
+                        PackageId = "Example.Search",
+                        Version = "1.0.0",
+                        TotalDownloads = 2,
+                        Versions = [new SearchResultVersion { Version = "1.0.0" }]
+                    }
+                ]
+            });
+        upstream
+            .Setup(client => client.SearchAsync("Example", 0, 20, false, default))
+            .ReturnsAsync(
+            [
+                new SearchResult
+                {
+                    PackageId = "Example.Search",
+                    Version = "1.0.0",
+                    TotalDownloads = 100,
+                    Versions = [new SearchResultVersion { Version = "1.0.0" }]
+                }
+            ]);
+        var target = CreateTarget(local, upstream, includeUpstream: true);
+
+        var response = await target.SearchAsync(request, default);
+
+        var package = Assert.Single(response.Data);
+        Assert.Equal(102, package.TotalDownloads);
+    }
+
+    private static PackageSearchService CreateTarget(
+        Mock<ISearchService> local,
+        Mock<IUpstreamClient> upstream,
+        bool includeUpstream)
+    {
+        return CreateTarget(local, upstream, new Mock<IUrlGenerator>(), includeUpstream);
+    }
+
+    private static PackageSearchService CreateTarget(
+        Mock<ISearchService> local,
+        Mock<IUpstreamClient> upstream,
+        Mock<IUrlGenerator> url,
+        bool includeUpstream,
+        INuGetUrlRewriter rewriter = null,
+        FullProxyOptions fullProxy = null)
+    {
+        if (rewriter is null)
+        {
+            var passthrough = new Mock<INuGetUrlRewriter>();
+            passthrough.Setup(r => r.RewriteAssetUrl(It.IsAny<string>())).Returns((string s) => s);
+            rewriter = passthrough.Object;
+        }
+
+        var hostProvider = new Mock<IUpstreamHostProvider>();
+        hostProvider
+            .Setup(h => h.EnsureResolvedAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        return new PackageSearchService(
+            local.Object,
+            upstream.Object,
+            url.Object,
+            rewriter,
+            hostProvider.Object,
+            new MemoryCache(new MemoryCacheOptions()),
+            Options.Create(new SearchOptions { IncludeUpstream = includeUpstream }),
+            Options.Create(fullProxy ?? new FullProxyOptions()));
+    }
+
+    private static SearchResponse EmptySearchResponse()
+    {
+        return new SearchResponse { Data = new List<SearchResult>() };
+    }
+}

--- a/tests/BaGetter.Core.Tests/ServiceIndex/BaGetterServiceIndexTests.cs
+++ b/tests/BaGetter.Core.Tests/ServiceIndex/BaGetterServiceIndexTests.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+namespace BaGetter.Core.Tests.ServiceIndex;
+
+public class BaGetterServiceIndexTests
+{
+    [Fact]
+    public async Task ServiceIndexUsesOnlyBaGetterUrls()
+    {
+        var url = new Mock<IUrlGenerator>();
+        url.Setup(u => u.GetPackagePublishResourceUrl()).Returns("http://localhost/api/v2/package");
+        url.Setup(u => u.GetSymbolPublishResourceUrl()).Returns("http://localhost/api/v2/symbol");
+        url.Setup(u => u.GetSearchResourceUrl()).Returns("http://localhost/v3/search");
+        url.Setup(u => u.GetPackageMetadataResourceUrl()).Returns("http://localhost/v3/registration/");
+        url.Setup(u => u.GetPackageContentResourceUrl()).Returns("http://localhost/v3/package/");
+        url.Setup(u => u.GetAutocompleteResourceUrl()).Returns("http://localhost/v3/autocomplete");
+        var target = new BaGetterServiceIndex(url.Object);
+
+        var response = await target.GetAsync();
+
+        Assert.NotEmpty(response.Resources);
+        Assert.All(response.Resources, resource =>
+        {
+            Assert.StartsWith("http://localhost/", resource.ResourceUrl);
+            Assert.DoesNotContain("nuget.org", resource.ResourceUrl);
+        });
+    }
+}

--- a/tests/BaGetter.Core.Tests/Services/PackageServiceTests.cs
+++ b/tests/BaGetter.Core.Tests/Services/PackageServiceTests.cs
@@ -180,6 +180,111 @@ public class PackageServiceTests
             Assert.Equal("3.0.0", ordered[2].Version.OriginalVersion);
         }
 
+        [Fact]
+        public async Task MergesUpstreamMetadataIntoLocalPackage()
+        {
+            var cacheDate = new DateTime(2026, 6, 11, 12, 0, 0, DateTimeKind.Utc);
+            var upstreamDate = new DateTime(2020, 4, 5, 10, 0, 0, DateTimeKind.Utc);
+            var localPackage = new Package
+            {
+                Version = new NuGetVersion("2.0.0"),
+                Downloads = 7,
+                HasReadme = false,
+                CachedFrom = "https://api.nuget.org/v3/index.json",
+                Listed = true,
+                Published = cacheDate
+            };
+            var upstreamPackage = new Package
+            {
+                Version = new NuGetVersion("2.0.0"),
+                Downloads = 123,
+                HasReadme = true,
+                Listed = false,
+                Published = upstreamDate,
+                ProjectUrl = new Uri("https://project.test/"),
+                RepositoryUrl = new Uri("https://github.com/bagetter/source"),
+                RepositoryType = "git"
+            };
+
+            Setup(
+                localPackages: new List<Package> { localPackage },
+                upstreamPackages: new List<Package> { upstreamPackage });
+
+            var result = await _target.FindPackagesAsync("MyPackage", _cancellationToken);
+
+            var package = Assert.Single(result);
+            Assert.NotSame(localPackage, package);
+            Assert.Equal(7, localPackage.Downloads);
+            Assert.False(localPackage.HasReadme);
+            Assert.Equal(cacheDate, localPackage.Published);
+            Assert.True(localPackage.Listed);
+            Assert.Equal(130, package.Downloads);
+            Assert.True(package.HasReadme);
+            Assert.Equal(upstreamDate, package.Published);
+            Assert.False(package.Listed);
+            Assert.Equal("https://project.test/", package.ProjectUrlString);
+            Assert.Equal("https://github.com/bagetter/source", package.RepositoryUrlString);
+            Assert.Equal("git", package.RepositoryType);
+        }
+
+        [Fact]
+        public async Task UsesUpstreamVisibilityMetadataForCachedPackageWithoutProvenance()
+        {
+            var cacheDate = new DateTime(2026, 6, 11, 12, 0, 0, DateTimeKind.Utc);
+            var upstreamDate = new DateTime(2020, 4, 5, 10, 0, 0, DateTimeKind.Utc);
+            var localPackage = new Package
+            {
+                Version = new NuGetVersion("2.0.0"),
+                Listed = true,
+                Published = cacheDate
+            };
+            var upstreamPackage = new Package
+            {
+                Version = new NuGetVersion("2.0.0"),
+                Listed = false,
+                Published = upstreamDate
+            };
+
+            Setup(
+                localPackages: new List<Package> { localPackage },
+                upstreamPackages: new List<Package> { upstreamPackage });
+
+            var result = await _target.FindPackagesAsync("MyPackage", _cancellationToken);
+
+            var package = Assert.Single(result);
+            Assert.Equal(upstreamDate, package.Published);
+            Assert.False(package.Listed);
+        }
+
+        [Fact]
+        public async Task PreservesLocalVisibilityMetadataWhenLocalPackageIsNotCached()
+        {
+            var localDate = new DateTime(2020, 4, 5, 10, 0, 0, DateTimeKind.Utc);
+            var upstreamDate = new DateTime(2026, 6, 11, 12, 0, 0, DateTimeKind.Utc);
+            var localPackage = new Package
+            {
+                Version = new NuGetVersion("2.0.0"),
+                Listed = true,
+                Published = localDate
+            };
+            var upstreamPackage = new Package
+            {
+                Version = new NuGetVersion("2.0.0"),
+                Listed = false,
+                Published = upstreamDate
+            };
+
+            Setup(
+                localPackages: new List<Package> { localPackage },
+                upstreamPackages: new List<Package> { upstreamPackage });
+
+            var result = await _target.FindPackagesAsync("MyPackage", _cancellationToken);
+
+            var package = Assert.Single(result);
+            Assert.Equal(localDate, package.Published);
+            Assert.True(package.Listed);
+        }
+
         private void Setup(
             IReadOnlyList<Package> localPackages = null,
             IReadOnlyList<Package> upstreamPackages = null)

--- a/tests/BaGetter.Core.Tests/Upstream/DisabledUpstreamClientTests.cs
+++ b/tests/BaGetter.Core.Tests/Upstream/DisabledUpstreamClientTests.cs
@@ -23,6 +23,22 @@ public class DisabledUpstreamClientTests
     }
 
     [Fact]
+    public async Task SearchAsync_IsCalled_ShouldReturnEmptyListAsync()
+    {
+        var result = await _disabledUpstreamClient.SearchAsync("dummy", 0, 20, false, default);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task AutocompleteAsync_IsCalled_ShouldReturnEmptyListAsync()
+    {
+        var result = await _disabledUpstreamClient.AutocompleteAsync("dummy", 0, 20, false, default);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
     public async Task ListPackagesAsync_IsCalled_ShouldReturnEmptyListAsync()
     {
         // Act
@@ -40,5 +56,19 @@ public class DisabledUpstreamClientTests
 
         // Assert
         Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task DownloadPackageReadmeOrNullAsync_IsCalled_ShouldReturnNull()
+    {
+        var result = await _disabledUpstreamClient.DownloadPackageReadmeOrNullAsync("dummy", default, default);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task EnrichPackageMetadataAsync_IsCalled_ShouldComplete()
+    {
+        await _disabledUpstreamClient.EnrichPackageMetadataAsync(new Package(), default);
     }
 }

--- a/tests/BaGetter.Core.Tests/Upstream/V3UpstreamClientTests.cs
+++ b/tests/BaGetter.Core.Tests/Upstream/V3UpstreamClientTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using BaGetter.Protocol;
@@ -131,6 +132,10 @@ public class V3UpstreamClientTests
                         MinClientVersion = "1.0.0",
                         PackageContentUrl = "https://content.test/",
                         Published = published,
+                        ProjectUrl = "https://project.test/",
+                        ReadmeUrl = "https://readme.test/",
+                        RepositoryUrl = "https://github.com/bagetter/source.test",
+                        RepositoryType = "git",
                         RequireLicenseAcceptance = true,
                         Summary = "Summary",
                         Title = "Title",
@@ -172,7 +177,7 @@ public class V3UpstreamClientTests
             Assert.Equal("Foo", package.Id);
             Assert.Equal(new[] { "Author1", "Author2" }, package.Authors);
             Assert.Equal("Description", package.Description);
-            Assert.False(package.HasReadme);
+            Assert.True(package.HasReadme);
             Assert.False(package.HasEmbeddedIcon);
             Assert.True(package.IsPrerelease);
             Assert.Null(package.ReleaseNotes);
@@ -186,12 +191,52 @@ public class V3UpstreamClientTests
             Assert.Equal("Title", package.Title);
             Assert.Equal("https://icon.test/", package.IconUrlString);
             Assert.Equal("https://license.test/", package.LicenseUrlString);
-            Assert.Equal("", package.ProjectUrlString);
-            Assert.Equal("", package.RepositoryUrlString);
-            Assert.Null(package.RepositoryType);
+            Assert.Equal("https://project.test/", package.ProjectUrlString);
+            Assert.Equal("https://github.com/bagetter/source.test", package.RepositoryUrlString);
+            Assert.Equal("git", package.RepositoryType);
             Assert.Equal(new[] { "Tag1", "Tag2" }, package.Tags);
             Assert.Equal("1.2.3-prerelease", package.NormalizedVersionString);
             Assert.Equal("1.2.3-prerelease+semver2", package.OriginalVersionString);
+
+            _client.Verify(
+                c => c.DownloadPackageManifestAsync(It.IsAny<string>(), It.IsAny<NuGetVersion>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+    }
+
+    public class EnrichPackageMetadataAsync : FactsBase
+    {
+        [Fact]
+        public async Task ReadsRepositoryMetadataFromManifest()
+        {
+            var package = new Package
+            {
+                Id = "Foo",
+                Version = _version,
+            };
+            _client
+                .Setup(c => c.DownloadPackageManifestAsync("Foo", _version, _cancellation))
+                .ReturnsAsync(StringStream("""
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+                      <metadata>
+                        <id>Foo</id>
+                        <version>1.2.3-prerelease+semver2</version>
+                        <authors>Author</authors>
+                        <description>Description</description>
+                        <projectUrl>https://project-from-nuspec.test/</projectUrl>
+                        <readme>README.md</readme>
+                        <repository type="git" url="https://github.com/bagetter/source-from-nuspec" />
+                      </metadata>
+                    </package>
+                    """));
+
+            await _target.EnrichPackageMetadataAsync(package, _cancellation);
+
+            Assert.True(package.HasReadme);
+            Assert.Equal("https://project-from-nuspec.test/", package.ProjectUrlString);
+            Assert.Equal("https://github.com/bagetter/source-from-nuspec", package.RepositoryUrlString);
+            Assert.Equal("git", package.RepositoryType);
         }
     }
 
@@ -250,6 +295,11 @@ public class V3UpstreamClientTests
             _target = new V3UpstreamClient(
                 _client.Object,
                 Mock.Of<ILogger<V3UpstreamClient>>());
+        }
+
+        protected static Stream StringStream(string content)
+        {
+            return new MemoryStream(Encoding.UTF8.GetBytes(content));
         }
     }
 }

--- a/tests/BaGetter.Tests/ProxyEndpointTests.cs
+++ b/tests/BaGetter.Tests/ProxyEndpointTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BaGetter.Tests;
+
+public class ProxyEndpointTests : IDisposable
+{
+    private readonly BaGetterApplication _app;
+    private readonly HttpClient _client;
+
+    public ProxyEndpointTests(ITestOutputHelper output)
+    {
+        // Full proxy enabled without an upstream: the trusted host set is empty, so
+        // the asset proxy rejects every URL. This exercises the SSRF guards and the
+        // endpoint wiring without any outbound network call.
+        _app = new BaGetterApplication(
+            output,
+            inMemoryConfiguration: config => config["FullProxy:Enabled"] = "true");
+        _client = _app.CreateClient();
+    }
+
+    [Fact]
+    public async Task RejectsNonHttpsUrl()
+    {
+        using var response = await _client.GetAsync("v3/proxy/asset?url=http://localhost/x");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RejectsUntrustedHost()
+    {
+        using var response = await _client.GetAsync("v3/proxy/asset?url=https://untrusted.example/x");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    public void Dispose()
+    {
+        _app.Dispose();
+    }
+}

--- a/tests/BaGetter.Tests/Support/BaGetApplication.cs
+++ b/tests/BaGetter.Tests/Support/BaGetApplication.cs
@@ -69,8 +69,10 @@ public class BaGetterApplication : WebApplicationFactory<Startup>
                     { "Storage:Type", "FileSystem" },
                     { "Storage:Path", storagePath },
                     { "Search:Type", "Database" },
+                    { "Search:IncludeUpstream", "false" },
                     { "Mirror:Enabled", _upstreamClient != null ? "true": "false" },
                     { "Mirror:PackageSource", "http://localhost/v3/index.json" },
+                    { "FullProxy:Enabled", "false" },
                 };
                 _inMemoryConfiguration?.Invoke(dict);
 

--- a/tests/BaGetter.Tests/UpstreamSearchIntegrationTests.cs
+++ b/tests/BaGetter.Tests/UpstreamSearchIntegrationTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace BaGetter.Tests;
+
+public class UpstreamSearchIntegrationTests : IDisposable
+{
+    private readonly BaGetterApplication _upstream;
+    private readonly BaGetterApplication _downstream;
+    private readonly HttpClient _downstreamClient;
+    private readonly Stream _packageStream;
+
+    public UpstreamSearchIntegrationTests(ITestOutputHelper output)
+    {
+        _upstream = new BaGetterApplication(output);
+        _downstream = new BaGetterApplication(
+            output,
+            _upstream.CreateClient(),
+            configuration => configuration["Search:IncludeUpstream"] = "true");
+        _downstreamClient = _downstream.CreateClient();
+        _packageStream = TestResources.GetResourceStream(TestResources.Package);
+    }
+
+    [Fact]
+    public async Task SearchAndAutocompleteIncludeUpstreamPackages()
+    {
+        await _upstream.AddPackageAsync(_packageStream);
+
+        using var searchResponse = await _downstreamClient.GetAsync("v3/search?q=TestData");
+        var searchContent = await searchResponse.Content.ReadAsStringAsync();
+        using var autocompleteResponse = await _downstreamClient.GetAsync("v3/autocomplete?q=Test");
+        var autocompleteContent = await autocompleteResponse.Content.ReadAsStringAsync();
+        using var versionsResponse = await _downstreamClient.GetAsync("v3/autocomplete?id=TestData");
+        var versionsContent = await versionsResponse.Content.ReadAsStringAsync();
+        using var browseResponse = await _downstreamClient.GetAsync("/?q=TestData");
+        var browseContent = await browseResponse.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, searchResponse.StatusCode);
+        Assert.Contains(@"""id"":""TestData""", searchContent);
+        Assert.Equal(HttpStatusCode.OK, autocompleteResponse.StatusCode);
+        Assert.Contains(@"""TestData""", autocompleteContent);
+        Assert.Equal(HttpStatusCode.OK, versionsResponse.StatusCode);
+        Assert.Contains(@"""1.2.3""", versionsContent);
+        Assert.Equal(HttpStatusCode.OK, browseResponse.StatusCode);
+        Assert.Contains("TestData", browseContent);
+    }
+
+    public void Dispose()
+    {
+        _packageStream.Dispose();
+        _upstream.Dispose();
+        _downstream.Dispose();
+    }
+}

--- a/tests/BaGetter.Web.Tests/Pages/IndexModelFacts.cs
+++ b/tests/BaGetter.Web.Tests/Pages/IndexModelFacts.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using BaGetter.Core;
 using BaGetter.Protocol.Models;
@@ -17,7 +17,7 @@ public class IndexModelFacts
 
     public IndexModelFacts()
     {
-        var search = new Mock<ISearchService>();
+        var search = new Mock<IPackageSearchService>();
         search
             .Setup(s => s.SearchAsync(It.IsAny<SearchRequest>(), _cancellation))
             .Callback((SearchRequest r, CancellationToken c) => _capturedRequest = r)

--- a/tests/BaGetter.Web.Tests/Pages/PackageModelFacts.cs
+++ b/tests/BaGetter.Web.Tests/Pages/PackageModelFacts.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BaGetter.Core;
+using BaGetter.Protocol.Models;
 using Moq;
 using NuGet.Versioning;
 using Xunit;
@@ -15,7 +16,8 @@ public class PackageModelFacts
 {
     private readonly Mock<IPackageContentService> _content;
     private readonly Mock<IPackageService> _packages;
-    private readonly Mock<ISearchService> _search;
+    private readonly Mock<IPackageSearchService> _search;
+    private readonly Mock<IUpstreamClient> _upstream;
     private readonly Mock<IUrlGenerator> _url;
     private readonly PackageModel _target;
 
@@ -25,17 +27,25 @@ public class PackageModelFacts
     {
         _content = new Mock<IPackageContentService>();
         _packages = new Mock<IPackageService>();
-        _search = new Mock<ISearchService>();
+        _search = new Mock<IPackageSearchService>();
+        _upstream = new Mock<IUpstreamClient>();
         _url = new Mock<IUrlGenerator>();
         _target = new PackageModel(
             _packages.Object,
             _content.Object,
             _search.Object,
+            _upstream.Object,
             _url.Object);
 
         _search
             .Setup(s => s.FindDependentsAsync("testpackage", _cancellation))
             .ReturnsAsync(new DependentsResponse());
+        _search
+            .Setup(s => s.SearchAsync(It.IsAny<SearchRequest>(), _cancellation))
+            .ReturnsAsync(new SearchResponse { Data = [] });
+        _upstream
+            .Setup(u => u.EnrichPackageMetadataAsync(It.IsAny<Package>(), _cancellation))
+            .Returns(Task.CompletedTask);
     }
 
     [Fact]
@@ -296,6 +306,41 @@ public class PackageModelFacts
         Assert.True(_target.Found);
         Assert.Equal(15, _target.TotalDownloads);
         Assert.Equal(now, _target.LastUpdated);
+    }
+
+    [Fact]
+    public async Task StatisticsUseExactSearchTotalDownloadsWhenAvailable()
+    {
+        _packages
+            .Setup(m => m.FindPackagesAsync("testpackage", _cancellation))
+            .ReturnsAsync(new List<Package>
+            {
+                CreatePackage("1.0.0", downloads: 7),
+            });
+        _search
+            .Setup(s => s.SearchAsync(It.IsAny<SearchRequest>(), _cancellation))
+            .ReturnsAsync(new SearchResponse
+            {
+                Data =
+                [
+                    new SearchResult { PackageId = "otherpackage", TotalDownloads = 999 },
+                    new SearchResult
+                    {
+                        PackageId = "testpackage",
+                        TotalDownloads = 130,
+                        Versions =
+                        [
+                            new SearchResultVersion { Version = "1.0.0", Downloads = 42 },
+                        ],
+                    },
+                ]
+            });
+
+        await _target.OnGetAsync("testpackage", "1.0.0", _cancellation);
+
+        Assert.True(_target.Found);
+        Assert.Equal(130, _target.TotalDownloads);
+        Assert.Equal(42, _target.Package.Downloads);
     }
 
     [Fact]


### PR DESCRIPTION
Add configurable upstream search and full proxy mode for upstream package assets in proxy deployments.

 * Add `SearchOptions.IncludeUpstream` to include upstream packages in search and autocomplete results.
 * Add `FullProxyOptions` to rewrite upstream package asset URLs (icons, licenses) to BaGetter endpoints.
 * Add `AssetProxyService` to fetch upstream assets server-side with in-memory caching.
 * Add `IPackageSearchService` and `PackageSearchService` as a search layer that queries both local and upstream sources.
 * Add `INuGetUrlRewriter`, `IUpstreamHostProvider` and related infrastructure for dynamic trusted host derivation.
 * Enrich `PackageMetadata` model with `ProjectUrl`, `ReadmeUrl`, `RepositoryUrl`, `RepositoryType`.
 * Fall back to upstream for readme streams when not embedded locally.
 * Add focused unit tests and integration tests.

## Why

Proxy deployments currently mirror only downloaded packages and serve only locally indexed packages in search. In locked-down environments where clients cannot reach the upstream feed, search needs to include upstream packages and asset URLs (icons, licenses) must be proxied through BaGetter so clients never contact the upstream directly.

## Full proxy

Full proxy mode implies upstream search—no separate `Search:IncludeUpstream` is needed when full proxy is enabled. The set of trusted upstream hosts is derived at runtime from the configured `Mirror` source (package source + service index resources), so this works for any provider without a static host list. Only assets hosted on the configured upstream's own infrastructure are proxied; author-supplied third-party URLs are left untouched.

Security: only HTTPS URLs on trusted hosts are proxied, HTTP redirects are disabled (SSRF via upstream-controlled 3xx), and loopback/private IP addresses are rejected.

## Search behavior

When `Search:IncludeUpstream` is enabled (or implied by full proxy), search and autocomplete query the upstream source alongside the local database. Upstream results include metadata fields (icons, licenses, project URLs, repository info) that are enriched from the upstream package manifest. The existing `ISearchService` (`Search:Type`, `Database` by default) continues to back the local database portion.

## Configuration

```json
{
  "Mirror": {
    "Enabled": true,
    "PackageSource": "https://api.nuget.org/v3/index.json"
  },
  "Search": {
    "IncludeUpstream": true
  },
  "FullProxy": {
    "Enabled": true,
    "CacheMinutes": 30,
    "AssetCacheMinutes": 1440
  }
}
```

`CacheMinutes` controls how long upstream search/autocomplete responses are cached (0 disables). `AssetCacheMinutes` controls how long proxied assets are cached (in-memory, per-instance).

## Validation

 * `dotnet build`
 * `dotnet test` (409 tests)
 * HTTP proxy smoke test:
   * Feature disabled: upstream search/autocomplete returns empty, proxy endpoint returns 400, web page returns 200.
   * Feature enabled: Spectre.Console appears in upstream search; registration/icon/license URLs rewritten to local proxy; detail page shows nuspec-matched source code, README, populated downloads without G-total bug, stable Last Updated.

No linked issue.